### PR TITLE
starting on optimizer

### DIFF
--- a/source/optimizer.civet
+++ b/source/optimizer.civet
@@ -1,0 +1,41 @@
+import type { HeraAST, HeraRules, SequenceNode, TerminalNode } from "./hera-types.ts"
+
+export optimize := (ast: HeraRules) ->
+  optimized := {} as HeraRules
+
+  Object.entries ast
+  .forEach ([ruleName, value]) ->
+    debugger
+    optimized[ruleName] = optimizeRule value
+
+  return optimized
+
+optimizeRule := (production: HeraAST): HeraAST ->
+  if production <? "string" // named rule
+    return production
+
+  if production[0] == "L" // string literal
+    return production
+
+  if production[0] == "S" // sequence
+    if production.length == 2 // No handler on sequence
+      return optimizeSequence production
+
+  return production
+
+isStringLiteral := (item: HeraAST) ->
+  if item <? "string" or item.length !== 2
+    return false
+
+  return item[0] == "L"
+
+optimizeSequence := (node: SequenceNode): SequenceNode | TerminalNode ->
+  items := node[1]
+  if items.every isStringLiteral
+    literalItems := items as ["L", string][]
+    return combineLiterals literalItems
+
+  return node
+
+combineLiterals := (literals: ["L", string][]): ["L", string] ->
+  ["L", literals.map(([,s]) => s).join("")]

--- a/test/optimize.civet
+++ b/test/optimize.civet
@@ -1,0 +1,52 @@
+{ optimize } from ../source/optimizer.civet
+assert from assert
+
+describe "AST Optimization", ->
+  it.only "should convert sequences of string literals into a single string literal", ->
+    ast := {
+      "Rule": [ "S", [
+        [ "L", "a" ],
+        [ "L", "b" ],
+        [ "L", "c" ]
+      ]]
+    }
+
+    optimized := {
+      "Rule": [ "L", "abc" ]
+    }
+
+    assert.deepEqual optimize(ast), optimized
+
+  it "should convert sequences of strings and regexps into a single regexp literal", ->
+    ast := {
+      "Rule": [ "S", [
+        [ "L", "a" ],
+        [ "R", "[^c]*" ],
+        [ "L", "c" ]
+      ]]
+    }
+
+
+  it "should optimize sequences and choices with aliases", ->
+    ast :=
+      "CharacterClass": [
+        "S",
+        [
+          [
+            "L",
+            "["
+          ],
+          [
+            "*",
+            "CharacterClassCharacter"
+          ],
+          [
+            "L",
+            "]"
+          ],
+          [
+            "?",
+            "Quantifier"
+          ]
+        ]
+      ],


### PR DESCRIPTION
I think we could improve performance quite a bit by doing simple optimizations:

- [ ] Combine adjacent RegExp and String literals
- [ ] Aggregate leaf nodes
- [ ] Skip single item Choice / Sequence
- [ ] Convert Choices / Sequences of leaf nodes to RegExps
- [ ] Convert `!`/ `&` assertions to RegExps
- [ ] Replace closed rules with their literal contents

It may be a little tricky to correctly remap the handlers, but maybe not.