### PR TITLE
esbuild plugin can be passed compile options

### DIFF
--- a/source/esbuild-plugin.civet
+++ b/source/esbuild-plugin.civet
@@ -2,18 +2,18 @@
 path := require 'path'
 { parse, compile } := require "./"
 
-module.exports =
+module.exports = (options) =>
   name: 'hera'
-  setup: (build) ->
+  setup: (build) =>
     build.onLoad { filter: /.\.hera$/ }, (args) ->
       readFile(args.path, 'utf8')
-      .then (source) ->
+      .then (source) =>
         filename := path.relative(process.cwd(), args.path)
 
         return {
-          contents: compile parse(source, { filename })
+          contents: compile source, { ...options, filename }
         }
-      .catch (e) ->
+      .catch (e) =>
         errors: [{
           text: e.message
         }]


### PR DESCRIPTION
(as discussed on Discord)

* I think `filename` was also previously passed into the wrong function (`parse` instead of `compile`)
* `parse` no longer needs to be called; `compile` calls `parse` if the first argument is a string

BREAKING CHANGE: esbuild plugin now needs to be called

I've tested this with `module: true` where I need it in my Civet branch.