### PR TITLE
Export ParseError, import URL

### DIFF
--- a/build/compile
+++ b/build/compile
@@ -16,7 +16,7 @@ chmod +x dist/hera
 
 # Compressed size check
 size=$(gzip - < dist/main.js | wc -c)
-MAX_SIZE=13000
+MAX_SIZE=14000
 
 if [ "${size}" -gt $MAX_SIZE ]; then
   echo "Size check failed: ${size} > $MAX_SIZE bytes"

--- a/build/esbuild.coffee
+++ b/build/esbuild.coffee
@@ -10,6 +10,7 @@ esbuild.build({
   entryPoints: ['source/main.civet']
   tsconfig: "./tsconfig.json"
   bundle: true
+  keepNames: true
   external: ["fs"]
   format: "cjs"
   sourcemap

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -449,6 +449,7 @@ cjsHead := """
     $TS,
     $TV,
     $Y,
+    ParseError,
     Parser,
     Validator
   } = require("./machine.js")
@@ -511,6 +512,7 @@ mjsHead := """
     $TS,
     $TV,
     $Y,
+    ParseError,
     Validator,
   } from "./machine.js"
 

--- a/source/machine.ts
+++ b/source/machine.ts
@@ -626,8 +626,7 @@ ${input.slice(result.pos)}
       else
         hint = "EOF"
 
-      const error = new ParseError(`${filename}:${line}:${column} Failed to parse
-Expected:
+      const error = new ParseError("Failed to parse", `Expected:
 \t${expectations.join("\n\t")}
 Found: ${hint}
 `, filename, line, column, maxFailPos)
@@ -662,12 +661,16 @@ ${input.slice(result.pos)}
 export class ParseError extends Error {
   name = "ParseError"
   constructor(
-    public message: string,
+    public header: string,
+    public body: string | undefined,
     public filename: string,
     public line: number,
     public column: number,
     public offset: number,
   ) {
+    let message = `${filename}:${line}:${column} ${header}`
+    if (body) message += `\n${body}`
     super(message)
+    this.message = message
   }
 }

--- a/source/machine.ts
+++ b/source/machine.ts
@@ -659,7 +659,7 @@ ${input.slice(result.pos)}
   }
 }
 
-class ParseError extends Error {
+export class ParseError extends Error {
   constructor(
     public message: string,
     public name: string,

--- a/source/machine.ts
+++ b/source/machine.ts
@@ -630,7 +630,7 @@ ${input.slice(result.pos)}
 Expected:
 \t${expectations.join("\n\t")}
 Found: ${hint}
-`, "ParseError", filename, line, column, maxFailPos)
+`, filename, line, column, maxFailPos)
 
       throw error
     }
@@ -660,9 +660,9 @@ ${input.slice(result.pos)}
 }
 
 export class ParseError extends Error {
+  name = "ParseError"
   constructor(
     public message: string,
-    public name: string,
     public filename: string,
     public line: number,
     public column: number,

--- a/source/main.civet
+++ b/source/main.civet
@@ -40,8 +40,8 @@ generate := <T extends HeraGrammar>(src: string) => {
 
 modImport := async <T extends HeraGrammar>(src: string) => {
   fs := await import('node:fs/promises')
-  { fileURLToPath } := await import "url"
-  { dirname } := await import "path"
+  { fileURLToPath, pathToFileURL } := await import "node:url"
+  { dirname } := await import "node:path"
 
   __dirname := dirname fileURLToPath(import.meta.url)
 
@@ -55,7 +55,7 @@ modImport := async <T extends HeraGrammar>(src: string) => {
   await fs.writeFile(tmpPath, js)
 
   try
-    (await import tmpPath) as {
+    (await import pathToFileURL(tmpPath).href) as {
       parse: (input: string, options?: ParserOptions<T>) => unknown
     }
   finally


### PR DESCRIPTION
This should enable fixing

https://github.com/DanielXMoore/Civet/blob/6197b5a53e510a9519df437c8e86c2c8198118c7/types/types.d.ts#L58

by adding this to `parser.hera`:

````
```
export { ParseError }
```
````

Also, `yarn test` isn't working on Windows, with error `Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs. Received protocol 'c:'`. I added some code that *should* fix this, but still doesn't seem to. Progress though I think.

I also updated the `ParseError` interface and constructor to provide more convenience:
* `header` field for the main message (first line after `filename:line:column`)
* `body` field for the multiple lines of expected rules
* `message` isn't an argument, but is automatically constructed as `filename:line:column header\nbody`
* No more `name` argument; it should be `"ParseError"` in all cases