### PR TITLE
Fix `buid/compile` script to work on macOS

### DIFF
--- a/build/compile
+++ b/build/compile
@@ -11,14 +11,14 @@ civet build/esbuild.civet
 # adjust .d.ts files
 for f in dist/**/*.civet.d.ts; do
   # replace all .civet imports with .js
-  sed -i 's/\.civet"/.js"/g' "$f"
+  sed -i '' 's/\.civet"/.js"/g' "$f"
   mv "$f" "${f%.civet.d.ts}.d.ts"
 done
 
 # hack to rewrite require extension
-sed --in-place -e 's/main.civet/main.js/' dist/hera
+sed -i '' -e 's/main.civet/main.js/' dist/hera
 # hack to remove import_meta and just use existing require
-sed --in-place -e '/import_meta/d' -e '/import_module/d' -e 's/require2/require/' dist/main.js
+sed -i '' -e '/import_meta/d' -e '/import_module/d' -e 's/require2/require/' dist/main.js
 # Mark 'hera' cli as executable
 chmod +x dist/hera
 

--- a/build/compile
+++ b/build/compile
@@ -8,17 +8,38 @@ mkdir dist
 cp source/machine.* dist/
 civet build/esbuild.civet
 
+# Cross-platform version of `sed -i`
+# Assumes that the last parameter is the file being modified
+#
+# Usage:
+#   sed_i -e '/import_meta/d' -e '/import_module/d' dist/main.js
+#     is equivalent to
+#   sed -i '' -e '/import_meta/d' -e '/import_module/d' dist/main.js
+#
+# Why? GNU and BSD sed don't both support -i in the same way.
+# See: https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux
+function sed_i() {
+  # Make a backup of the file with .bak as the extension
+  sed -i.bak "$@"
+
+  # Remove the backup file. Assumes the last parameter is the file being modified.
+  rm "${@: -1}.bak"
+}
+
 # adjust .d.ts files
 for f in dist/**/*.civet.d.ts; do
   # replace all .civet imports with .js
-  sed -i '' 's/\.civet"/.js"/g' "$f"
+  sed_i 's/\.civet"/.js"/g' "$f"
+
   mv "$f" "${f%.civet.d.ts}.d.ts"
 done
 
 # hack to rewrite require extension
-sed -i '' -e 's/main.civet/main.js/' dist/hera
+sed_i -e 's/main.civet/main.js/' dist/hera
+
 # hack to remove import_meta and just use existing require
-sed -i '' -e '/import_meta/d' -e '/import_module/d' -e 's/require2/require/' dist/main.js
+sed_i -e '/import_meta/d' -e '/import_module/d' -e 's/require2/require/' dist/main.js
+
 # Mark 'hera' cli as executable
 chmod +x dist/hera
 


### PR DESCRIPTION
Because macOS ships with the BSD version of sed, the `-i` flag requires specifying a backup file extension (even if it’s just empty). GNU sed allows -i with no extension.

I haven't tried this out on Linux... I figured CI would let us know if it doesn't work.
