### PR TITLE
Typecheck parser samples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage/
 dist/
 node_modules/
 source/machine.js
+parsers/

--- a/build/typed-parser-samples
+++ b/build/typed-parser-samples
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euox pipefail
+shopt -s globstar
+
+cd "$(dirname "$0")/.."
+
+export NODE_OPTIONS='--require=./node_modules/@danielx/hera/register'
+export PATH="$PWD/node_modules/.bin:$PATH"
+
+rm -rf ./parsers
+mkdir -p ./parsers
+
+for grammar in regex.hera ; do
+  civet source/cli.civet --types --libPath ../source/machine < "samples/$grammar" > "parsers/$grammar.ts"
+done

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "prepublishOnly": "yarn build && yarn test",
     "benchmark": "NODE_OPTIONS='--require=./node_modules/@danielx/hera/register' civet ./perf/benchmark.civet",
     "build": "bash build/compile",
-    "test": "c8 mocha"
+    "test": "c8 mocha && yarn test:typed-parser-samples",
+    "test:typed-parser-samples": "build/typed-parser-samples && tsc --noEmit parsers/*.ts"
   },
   "bin": {
     "hera": "dist/hera"

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -490,6 +490,7 @@ jsTail := """
 cjsExport := """
   exports.default = parser
   const parse = exports.parse = parser.parse
+  void parse // make TS ok if we don't use this variable
 """
 
 mjsHead := """
@@ -520,9 +521,12 @@ mjsHead := """
 
 tsHead := mjsHead.replace("}", """
   type ParserContext,
+  type ParserOptions,
   type ParseState,
 }
-""")
+""") +
+  "\nvoid " + mjsHead.match(/\{[\s\S]+\}/m)![0] // quick-and-dirty way to void all the imports so that TS doesn't complain if they aren't used
+
 
 tsTail := """
   const parser = (function() {

--- a/source/hera-types.civet
+++ b/source/hera-types.civet
@@ -2,7 +2,9 @@
  * These are types specific to the Hera parser and not grammars in general.
  */
 
-import type { Loc, Parser, ParserContext } from "./machine"
+import type { Loc, ParserContext, HeraGrammar, ParserOptions } from "./machine"
+
+export type ParserContext, HeraGrammar, ParserOptions
 
 export type Terminal = string | RegExp
 
@@ -36,19 +38,4 @@ export const CodeSymbol = Symbol.for("code")
 export type HeraRules = {
   [key: string]: HeraAST,
   [CodeSymbol]?: string
-}
-
-export type HeraGrammar = { [key: string]: Parser<any> }
-
-export type ParserEvents = {
-  enter?: ParserContext["enter"],
-  exit?: ParserContext["exit"],
-}
-
-export interface ParserOptions<T extends HeraGrammar> {
-  /** The name of the file being parsed */
-  filename?: string
-  startRule?: keyof T
-  tokenize?: boolean
-  events?: ParserEvents
 }

--- a/source/machine.ts
+++ b/source/machine.ts
@@ -674,3 +674,18 @@ export class ParseError extends Error {
     this.message = message
   }
 }
+
+export type ParserEvents = {
+  enter?: ParserContext["enter"],
+  exit?: ParserContext["exit"],
+}
+
+export type HeraGrammar = { [key: string]: Parser<any> }
+
+export interface ParserOptions<T extends HeraGrammar> {
+  /** The name of the file being parsed */
+  filename?: string
+  startRule?: keyof T
+  tokenize?: boolean
+  events?: ParserEvents
+}


### PR DESCRIPTION
As part of `yarn test`, generate some parsers from `./samples` (using the `--types`) and then typecheck them.

This is a more piecemeal way of getting Hera's types in order than #25.

You may want to look at the individual commits in this PR.
- The first commit adds the infrastructure to test `regex.hera` and will fail in CI
- The second commit makes some minor changes to the type generation so that CI will pass

For now, this PR can include only the most basic parser samples, but over time, we can tighten the screws by
- typechecking more parsers from `samples`
- including some trickier parsers specifically designed to test the generated types
- eventually typechecking Hera's own parser

A few notes/questions:

I didn't know the best place to put the generated parsers. Maybe they should go in a `tmp/typed-parsers/` directory? I don't think they should be committed.

Should this be done from inside the mocha test suite?