### PR TITLE
Typecheck more sample parsers

### DIFF
--- a/build/typed-parser-samples
+++ b/build/typed-parser-samples
@@ -14,5 +14,8 @@ function compile_parser() {
   civet source/cli.civet --types --libPath ../source/machine < "$1" > "parsers/$(basename "$1").ts"
 }
 
+compile_parser samples/code.hera
 compile_parser samples/regex.hera
 compile_parser samples/url.hera
+compile_parser samples/coffee.hera
+compile_parser samples/structural-mapping.hera

--- a/build/typed-parser-samples
+++ b/build/typed-parser-samples
@@ -10,6 +10,6 @@ export PATH="$PWD/node_modules/.bin:$PATH"
 rm -rf ./parsers
 mkdir -p ./parsers
 
-for grammar in regex.hera ; do
+for grammar in regex.hera url.hera; do
   civet source/cli.civet --types --libPath ../source/machine < "samples/$grammar" > "parsers/$grammar.ts"
 done

--- a/build/typed-parser-samples
+++ b/build/typed-parser-samples
@@ -10,6 +10,9 @@ export PATH="$PWD/node_modules/.bin:$PATH"
 rm -rf ./parsers
 mkdir -p ./parsers
 
-for grammar in regex.hera url.hera; do
-  civet source/cli.civet --types --libPath ../source/machine < "samples/$grammar" > "parsers/$grammar.ts"
-done
+function compile_parser() {
+  civet source/cli.civet --types --libPath ../source/machine < "$1" > "parsers/$(basename "$1").ts"
+}
+
+compile_parser samples/regex.hera
+compile_parser samples/url.hera

--- a/samples/url.hera
+++ b/samples/url.hera
@@ -20,6 +20,7 @@ Authority
     return {
       host: $2,
       port: $3,
+      path: '',
     }
 
 Port


### PR DESCRIPTION
Adds more of the parsers in `samples/` to the list that get checked.

- Adjust `url.hera` to pass the typecheck
- No changes to the compiler


