### PR TITLE
Add sample parser that tests the generated type annotions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ and the matching string is available as `$0`.
 
 **Lookahead predicates** (`&`, `!`): `&...` and `!...` assert the existence or non-existence, respectively, of a match of `...`, without advancing the position or consuming any input. For example, `&/\s/` is like the look-ahead regular expression `/(?=\s)/`.
 
-**Stringify** (`*`): `*...` matches `...` but returns just the string of the input that matched, instead of the computed return value from the matching process (from handlers and the arrays from sequences and repetitions).
+**Stringify** (`$`): `$...` matches `...` but returns just the string of the input that matched, instead of the computed return value from the matching process (from handlers and the arrays from sequences and repetitions).
 
 **Handler**: A mapping from the matched choice to a language primitive.
 Handlers are attached to rule choices by adding `->` after the choice.

--- a/build/typed-parser-samples
+++ b/build/typed-parser-samples
@@ -22,3 +22,4 @@ compile_parser samples/structural-mapping.hera
 compile_parser samples/math.hera
 compile_parser samples/named-params.hera
 compile_parser samples/unary-subtract.hera
+compile_parser samples/types.hera

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "benchmark": "NODE_OPTIONS='--require=./node_modules/@danielx/hera/register' civet ./perf/benchmark.civet",
     "build": "bash build/compile",
     "test": "c8 mocha && yarn test:typed-parser-samples",
-    "test:typed-parser-samples": "build/typed-parser-samples && tsc --noEmit parsers/*.ts"
+    "test:typed-parser-samples": "build/typed-parser-samples && tsc --noEmit --strict parsers/*.ts"
   },
   "bin": {
     "hera": "dist/hera"

--- a/samples/math.hera
+++ b/samples/math.hera
@@ -1,15 +1,19 @@
 Expression
   Term (_ ("+" / "-") _ Term)* ::number ->
     return $2.reduce(function(result, element) {
-      if (element[1] === "+") { return result + element[3]; }
-      if (element[1] === "-") { return result - element[3]; }
+      switch (element[1]) {
+        case "+": return result + element[3];
+        case "-": return result - element[3];
+      }
     }, $1);
 
 Term
   Factor (_ ("*" / "/") _ Factor)* ->
     return $2.reduce(function(result, element) {
-      if (element[1] === "*") { return result * element[3]; }
-      if (element[1] === "/") { return result / element[3]; }
+      switch (element[1]) {
+        case "*": return result * element[3];
+        case "/": return result / element[3];
+      }
     }, $1)
 
 Factor

--- a/samples/types.hera
+++ b/samples/types.hera
@@ -1,0 +1,190 @@
+# A grammar to test the generated type annotions of the parser.
+# The generated parser code should be able to typecheck.
+
+```
+/* A helper that will fail to typecheck if the type of _actual is not in T.
+
+Warning: If T is broader than `_actual` then it will pass the type check.
+E.g. these all pass even though one might not expect them to:
+  expectType<string>(x as 'a' | 'b')
+  expectType<"a"|"b"|"c">(x as 'a')
+  expectType<string|number>(x as 'a')
+*/
+function expectType<T>(_actual: T) {}
+
+// a little helper to make the assertions easier to read
+function fromRule<K extends keyof Grammar>(startRule: K) {
+  return parse<K>("", { startRule })
+}
+```
+
+
+```
+expectType<number>(fromRule('StartRule'))
+expectType<number>(parse("")) // defaults to the first rule
+```
+StartRule
+  Numeric
+
+
+```
+expectType<string>(fromRule('RegexAsString'))
+```
+RegexAsString
+  /[a-zA-Z]+/
+
+
+```
+expectType<"foo"|"bar"|"<\"'`>">(fromRule('RegexAsConstUnion'))
+```
+RegexAsConstUnion
+  /foo|bar|<"'`>/
+
+
+```
+expectType<"a"|"b"|"c">(fromRule('RegexSimpleCharacterClassAsConstUnion'))
+```
+RegexSimpleCharacterClassAsConstUnion
+  /[abc]/
+
+
+```
+expectType<number>(fromRule('InferredFromSingleChoice'))
+```
+InferredFromSingleChoice
+  Numeric
+
+
+```
+expectType<string | number | "aaa"[]>(fromRule('InferredFromMultipleChoices'))
+```
+InferredFromMultipleChoices
+  Numeric
+  Alpha
+  "aaa"*
+
+
+```
+expectType<string | number | "aaa"[]>(fromRule('InferredFromChoices'))
+```
+InferredFromChoices
+  Numeric / Alpha / "aaa"*
+
+
+```
+expectType<number>(fromRule('StructuralHandlerTopLevel'))
+```
+StructuralHandlerTopLevel
+  Alpha Numeric -> $2
+
+
+```
+expectType<(number | string | {nested:number})[]>(fromRule('StructuralHandlerArray'))
+```
+StructuralHandlerArray
+  Numeric Alpha -> [$2, $1, $1, { nested: $1 }]
+
+
+```
+expectType<{
+  numberProp: number,
+  stringProp: string,
+  constantString: string,
+  arrayProp: (number | string)[],
+  objectProp: { n: number, s: string },
+}>(fromRule('StructuralHandlerObject'))
+```
+StructuralHandlerObject
+  Numeric Alpha -> {
+    numberProp: $1,
+    stringProp: $2,
+    constantString: "foo",
+    arrayProp: [$1, $2, $1, $2],
+    objectProp: { n: $1, s: $2 },
+  }
+
+
+```
+let explicitTypeResult = fromRule('ExplicitType')
+void explicitTypeResult // make TS happy with us not using the variable
+
+// this will fail the type check if the explicit type annotation is not being applie
+explicitTypeResult = new Date()
+```
+ExplicitType
+  Numeric ::{foo:number}|Date ->
+    return { foo: $1 }
+
+
+```
+expectType<{foo:number}>(fromRule('InferredFromHandlerReturnType'))
+```
+InferredFromHandlerReturnType
+  Numeric ->
+    return { foo: $1 }
+
+
+# Testing that the basic op results are passed to handlers as the correct types
+BasicTypesOfOps
+  "aaa" ->
+    expectType<string>($1)
+
+  /aaa/ ->
+    // TODO: shouldn't $1 be type "aaa"?
+    expectType<string>($1)
+
+  /[abc]/ ->
+    // TODO: shouldn't $1 be type "a"|"b"|"c"?
+    expectType<string>($1)
+
+  /a(a)+/ ->
+    // $0 is the entire match
+    expectType<string>($0)
+
+    // currently we get $1 through $9 as strings regardless of whether there are 9 captured groups
+    expectType<string>($1)
+    expectType<string>($2)
+    expectType<string>($3)
+
+  Numeric ->
+    expectType<number>($1)
+
+  &Numeric ->
+    expectType<undefined>($1)
+
+  $Numeric ->
+    expectType<string>($1)
+
+  !Numeric ->
+    expectType<undefined>($1)
+
+  Numeric? ->
+    expectType<number|undefined>($1)
+
+  Numeric* ->
+    expectType<number[]>($1)
+
+  Numeric* ->
+    expectType<number[]>($1)
+
+  Numeric+ ->
+    expectType<number[]>($1)
+
+  $(Numeric*) ->
+    expectType<string>($1)
+
+  Numeric !Alpha Numeric* ->
+    // `!Alpha` is passed as a parameter that is undefined (as opposed to being omitted from the parameter list)
+
+    expectType<[number, undefined, number[]]>($0)
+
+    expectType<number>($1)
+    expectType<undefined>($2)
+    expectType<number[]>($3)
+
+
+Alpha
+  /[a-zA-Z]+/
+Numeric
+  /[0-9]+/ ->
+    return Number($1)

--- a/samples/types.hera
+++ b/samples/types.hera
@@ -130,11 +130,9 @@ BasicTypesOfOps
     expectType<string>($1)
 
   /aaa/ ->
-    // TODO: shouldn't $1 be type "aaa"?
     expectType<string>($1)
 
   /[abc]/ ->
-    // TODO: shouldn't $1 be type "a"|"b"|"c"?
     expectType<string>($1)
 
   /a(a)+/ ->

--- a/source/machine.ts
+++ b/source/machine.ts
@@ -482,7 +482,7 @@ export function $R$0(parser: Parser<RegExpMatchArray>): Parser<string> {
 }
 
 /**
- * Handles triggering enter/exit events and early reslut returning from results cache for a
+ * Handles triggering enter/exit events and early result returning from results cache for a
  * single rule.
  */
 export function $EVENT<T>(ctx: ParserContext, state: ParseState, name: string, fn: Parser<T>) {
@@ -509,7 +509,7 @@ type ParserReturnTypes<T extends Parser<any>[]> =
   T[number] extends Parser<infer P> ? MaybeResult<P> : never
 
 /**
- * Handles triggering enter/exit events and early reslut returning from results cache for an
+ * Handles triggering enter/exit events and early result returning from results cache for an
  * array of rules where the first match is returned (Choice).
  */
 export function $EVENT_C<T extends Parser<any>[]>(ctx: ParserContext, state: ParseState, name: string, fns: T): ParserReturnTypes<T> {


### PR DESCRIPTION
- add `samples/types.hera`, a parser designed to exercise and test the generated type annotations
- add `--strict` to `tsc` parameters
- adjust `samples/math.hera` to pass the `--strict` rules
- no changes to the compiler