### PR TITLE
Move type annotations to Regex definitions

### DIFF
--- a/samples/types.hera
+++ b/samples/types.hera
@@ -127,13 +127,16 @@ InferredFromHandlerReturnType
 # Testing that the basic op results are passed to handlers as the correct types
 BasicTypesOfOps
   "aaa" ->
-    expectType<string>($1)
+    expectType<"aaa">($0)
+    expectType<"aaa">($1)
 
   /aaa/ ->
-    expectType<string>($1)
+    expectType<"aaa">($0)
+    expectType<undefined>($1)
 
   /[abc]/ ->
-    expectType<string>($1)
+    expectType<"a"|"b"|"c">($0)
+    expectType<undefined>($1)
 
   /a(a)+/ ->
     // $0 is the entire match

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -74,7 +74,7 @@ compileOp := (tuple: HeraAST, name: string, defaultHandler: boolean, types?: boo
           args := tuple[1]
           let f = `$EXPECT(${defineRe(args)}, ${JSON.stringify(prettyPrint(name, args, true))})`
           if defaultHandler
-            f =`$R$0(${f})${reType(types, args)}`
+            f =`$R$0(${f})`
 
           f
         }
@@ -334,7 +334,7 @@ export function compile(rules: HeraRules, maybeOptions?: CompilerOptions): strin
     `const $L${i} = $L("${str}");\n`
 
   reDefSource := reDefs.map (r, i) ->
-    `const $R${i} = $R(new RegExp(${JSON.stringify(r)}, 'suy'));\n`
+    `const $R${i} = $R${reTupleType(types, r)}(new RegExp(${JSON.stringify(r)}, 'suy'));\n`
 
   genOpts: GenerateOptions := {}
 
@@ -388,22 +388,21 @@ isSimpleCharacterClass := /^\[[^-^\\]*\]$/
 Generate a more specific TypeScript type for Regular expressions that consist of
 limited productions. Returns an empty string if `types` is `false`.
 */
-reType := (types: boolean | undefined, str: string) ->
-  if types
-    let specifics: string[] | undefined
-    if str.match(isSimple)
-      specifics = str.split("|").map (s) ->
-        JSON.stringify(s)
-    else if str.match(isSimpleCharacterClass)
-      specifics = str.substring(1, str.length-1).split("").map (s) ->
-        JSON.stringify(s)
+reTupleType := (types: boolean?, reSource: string) ->
+  return "" unless types
 
-    if specifics
-      ` as Parser<${specifics.join("|")}>`
+  constTypes :=
+    if reSource.match(isSimple)
+      reSource.split("|")
+    else if reSource.match(isSimpleCharacterClass)
+      reSource.substring(1, reSource# - 1).split("")
     else
-      ""
-  else
-    ""
+      return ""
+
+  constTypes
+    .map JSON.stringify(.)
+    .join("|")
+    |> `<[${&}]>`
 
 type ASTNode = string | ASTNode[] | { $loc: { pos: number }, token: string, offset?: number } | { children: ASTNode[] } | undefined
 type GenerateOptions = {

--- a/test/main.civet
+++ b/test/main.civet
@@ -130,7 +130,7 @@ describe "Hera", ->
     """
     tsSrc := compile hera.parse(heraSrc), types: true
 
-    assert tsSrc.includes('Parser<"abc">')
+    assert tsSrc.includes('$R<["abc"]>')
 
   it "should annotate rules with types with handlers ", ->
     heraSrc := """


### PR DESCRIPTION
Fixes #32 

Move the type annotations to the regex definitions (e.g. `const $R1 = $R<['abc']>(...)`.
This causes the types to propagate to handler parameters.

Additionally
- adjust the inferred parameter types given to handlers of simple regexes. If $0 is typed as a const string, extra handler parameters are typed as undefined instead of string.
- Fix the types.hera examples that incorrectly used $1 instead of $0 for handler parameters. This was not caught before because $0..$9 were previously typed as string.