### PR TITLE
Add types to samples/hera_v0_8.hera

### DIFF
--- a/build/typed-parser-samples
+++ b/build/typed-parser-samples
@@ -23,3 +23,10 @@ compile_parser samples/math.hera
 compile_parser samples/named-params.hera
 compile_parser samples/unary-subtract.hera
 compile_parser samples/types.hera
+
+compile_parser samples/hera_v0_8.hera
+# hera_v0_8.hera depends on hera-types.civet which depends on machine.ts.
+# Since we're compiling these parsers with the source/ version instead of dist/,
+# we need to compile these, too so they are avaible to hera_v0_8.hera.
+civet --compile source/hera-types.civet --output parsers/hera-types.ts
+tsc source/machine.ts --declaration --emitDeclarationOnly --outDir parsers --target es6 --moduleResolution bundler

--- a/samples/hera_v0_8.hera
+++ b/samples/hera_v0_8.hera
@@ -1,8 +1,21 @@
+```
+import {
+  CodeSymbol,
+  type SequenceNode,
+  type NameNode,
+  type Handler,
+  type StructuralTerminal,
+  type StructuralObject,
+  type HeraAST,
+  type HeraRules,
+} from './hera-types'
+```
+
 Grammar
   Statement* ->
-    const code = $1.filter(a => typeof a === "string")
-    const rules = Object.fromEntries($1.filter(a => Array.isArray(a)))
-    rules[Symbol.for("code")] = code
+    const code = $1.filter(a => typeof a === "string") as string[]
+    const rules: HeraRules = Object.fromEntries($1.filter(a => Array.isArray(a)) as [string, HeraAST][])
+    rules[CodeSymbol] = code
     return rules
 
 Statement
@@ -25,17 +38,17 @@ Choice
   Sequence Handling ->
     if ($2 !== undefined) {
       if (!$1.push)
-        $1 = ["S", [$1], $2]
+        $1 = ["S", [$1], $2] as SequenceNode
       else
-        $1.push($2)
+        $1.push($2 as Handler)
     }
     return $1
 
 Sequence
-  Expression SequenceExpression+ ->
+  Expression SequenceExpression+ ::SequenceNode ->
     $2.unshift($1)
     return ["S", $2]
-  Expression ChoiceExpression+ ->
+  Expression ChoiceExpression+ ::SequenceNode ->
     $2.unshift($1)
     return ["/", $2]
   Expression
@@ -50,13 +63,13 @@ ParameterName
   ":" Name -> $2
 
 Expression
-  PrefixOperator? Suffix ParameterName? ->
+  PrefixOperator? Suffix ParameterName? ::SequenceNode|NameNode ->
     var result = null
     if ($1) result = [$1, $2]
     else result = $2
     if ($3)
-      return [{name: $3}, result]
-    return result
+      return [{name: $3}, result] as NameNode
+    return result as SequenceNode
 
 PrefixOperator
   [$&!]
@@ -82,7 +95,10 @@ Handling
   EOS ->
     return undefined
   Space* TypeAnnotation? Arrow HandlingExpression ->
-    if ($2) $4.t = $2
+    if ($2) {
+      if ($4 && typeof $4 === 'object' && 'f' in $4) $4.t = $2
+      else throw new Error(`TypeAnnotation is current only supported for handler functions but you passed ${JSON.stringify($4)}`)
+    }
     return $4
 
 HandlingExpression
@@ -90,7 +106,7 @@ HandlingExpression
   StructuralMapping EOS -> $1
 
 HandlingExpressionBody
-  HandlingExpressionLine+ ->
+  HandlingExpressionLine+ ::Handler ->
     return {
       f: $1.join("").trimEnd(),
       $loc,
@@ -101,7 +117,7 @@ HandlingExpressionLine
 
 StructuralMapping
   StringValue ->
-    return JSON.parse(`"${$1}"`)
+    return JSON.parse(`"${$1}"`) as string
   NumberValue
   BooleanValue
   NullValue
@@ -110,13 +126,14 @@ StructuralMapping
   JSObject
 
 JSArray
-  OpenBracket ArrayItem* CloseBracket -> $2
+  OpenBracket ArrayItem* CloseBracket ::StructuralTerminal[] ->
+    return $2 as StructuralTerminal[]
 
 ArrayItem
   StructuralMapping /,\s*|\s*(?=\])/ -> $1
 
 JSObject
-  OpenBrace ObjectField* CloseBrace ->
+  OpenBrace ObjectField* CloseBrace ::StructuralObject ->
     return {
       o: Object.fromEntries($2)
     }

--- a/samples/hera_v0_8.hera
+++ b/samples/hera_v0_8.hera
@@ -6,15 +6,13 @@ import {
   type Handler,
   type StructuralTerminal,
   type StructuralObject,
-  type HeraAST,
-  type HeraRules,
 } from './hera-types'
 ```
 
 Grammar
   Statement* ->
-    const code = $1.filter(a => typeof a === "string") as string[]
-    const rules: HeraRules = Object.fromEntries($1.filter(a => Array.isArray(a)) as [string, HeraAST][])
+    const code = $1.filter(a => typeof a === "string")
+    const rules = Object.fromEntries($1.filter(a => Array.isArray(a)))
     rules[CodeSymbol] = code
     return rules
 
@@ -38,9 +36,9 @@ Choice
   Sequence Handling ->
     if ($2 !== undefined) {
       if (!$1.push)
-        $1 = ["S", [$1], $2] as SequenceNode
+        $1 = ["S", [$1], $2]
       else
-        $1.push($2 as Handler)
+        $1.push($2)
     }
     return $1
 

--- a/samples/hera_v0_8.hera
+++ b/samples/hera_v0_8.hera
@@ -97,7 +97,7 @@ Handling
       if ($4 && typeof $4 === 'object' && 'f' in $4) $4.t = $2
       else throw new Error(`TypeAnnotation is current only supported for handler functions but you passed ${JSON.stringify($4)}`)
     }
-    return $4
+    return $4 as Handler
 
 HandlingExpression
   EOS HandlingExpressionBody EOS? -> $2

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -124,33 +124,33 @@ regularHandlerParams := ["$skip", "$loc", "$0", "$1"]
 // and regexps start at the second because the first is the entire match
 // TODO: is 0 valid to select the entire sequence result?
 // TODO: remove offset and unify handlings
-compileStructuralHandler := (mapping: StructuralHandling, source: any, single=false, offset=-1): string ->
+compileStructuralHandler := (mapping: StructuralHandling, single=false, offset=-1): string ->
   switch typeof mapping
     when "string"
       JSON.stringify(mapping)
     when "object"
       if Array.isArray mapping
-        `[${mapping.map((m) => compileStructuralHandler(m, source, single, offset)).join(', ')}]`
+        `[${mapping.map((m) => compileStructuralHandler(m, single, offset)).join(', ')}]`
       else if mapping is null
         "null"
       else if "l" in mapping
         String(mapping.l)
       else if "v" in mapping
         if single
-          source
+          "value"
         else
           if typeof mapping.v is 'number'
             n := mapping.v+offset
             if n is -1 // Handle $0
-              source
+              "value"
             else // Handle $1, $2, etc.
-              `${source}[${n}]`
+              `value[${n}]`
           else
             mapping.v
       else if "o" in mapping
         o := mapping.o
         "{" + Object.keys(o).map (key) ->
-          `${JSON.stringify(key)}: ${compileStructuralHandler(o[key], source, single, offset)}`
+          `${JSON.stringify(key)}: ${compileStructuralHandler(o[key], single, offset)}`
         .join(", ") + "}"
       else
         throw new Error "unknown object mapping"
@@ -224,12 +224,12 @@ compileHandler := (variableName: string,options: CompilerOptions, arg: HeraAST, 
           else
             ""
         .join("")
-        return `${variableName} = $T(${parser}, function(value) {${namedParameters}return ${compileStructuralHandler(h, "value")} });`
+        return `${variableName} = $T(${parser}, function(value) {${namedParameters}return ${compileStructuralHandler(h)} });`
       else if arg[0] is "R"
-        return `${variableName} = $T(${parser}, function(value) { return ${compileStructuralHandler(h, "value", false, 0)} });`
+        return `${variableName} = $T(${parser}, function(value) { return ${compileStructuralHandler(h, false, 0)} });`
       else
         // This is 'single' so if there is a named variable it comes out as 'value'
-        return `${variableName} = $T(${parser}, function(value) { return ${compileStructuralHandler(h, "value", true)} });`
+        return `${variableName} = $T(${parser}, function(value) { return ${compileStructuralHandler(h, true)} });`
 
   return `${variableName} = ${compileOp(arg, name, true, options.types)}`
 

--- a/source/hera-types.civet
+++ b/source/hera-types.civet
@@ -16,7 +16,7 @@ export type StructuralTerminal =
   string |
   undefined |
   { v: PositionalVariable } |
-  StructuralObject |
+  { o: StructuralObject } |
   { l: any }
 export type StructuralObject = { [key: string]: StructuralHandling }
 export type StructuralHandling = StructuralTerminal | StructuralHandling[]

--- a/source/hera-types.civet
+++ b/source/hera-types.civet
@@ -16,8 +16,9 @@ export type StructuralTerminal =
   string |
   undefined |
   { v: PositionalVariable } |
-  { o: { [key: string]: StructuralHandling } } |
+  StructuralObject |
   { l: any }
+export type StructuralObject = { [key: string]: StructuralHandling }
 export type StructuralHandling = StructuralTerminal | StructuralHandling[]
 export type Handler = { $loc: Loc, f: string, t?: string } | StructuralHandling
 export type TerminalOp = "L" | "R"
@@ -37,5 +38,5 @@ export const CodeSymbol = Symbol.for("code")
 
 export type HeraRules = {
   [key: string]: HeraAST,
-  [CodeSymbol]?: string
+  [CodeSymbol]?: string | string[]
 }


### PR DESCRIPTION
Add types to `samples/hera_v0_8.hera`.

Before this PR `samples/hera_v0_8.hera` was a copy of `source/hera.hera`. I'm not sure if editing `samples/hera_v0_8.hera` is the best next step or if we should just make the changes directly to `source/hera.hera`. A few reasons that maybe these changes should just go in `hera.hera`
- `samples/hera_v0_8.hera`'s behavior isn't tested by the test suite
- `v0_8` would no longer be correct


## What's in this PR
- no changes to the compiler
- add type annotations to the .hera file
- add `samples/hera_v0_8.hera` to the list of samples that get compiled and typechecked
- adjust handlers to make TypeScript happy
- throw error when using a type annotation on a rule that accepts it but
  won't use it
- adjust `hera-types.civet` to be amenable to being used by the .hera file
- correct the HeraRules type

## Questions
- should this change be made directly on `source/hera.hera`?
- what's the right error to be thrown when type annotations are given to rules that don't do anything with the annotations? (It's a temporary problem b/c we'll probably soon make the other kinds of rules use the type annotations)
- this project currently depends on TypeScript 5.2.2. I believe that later versions of typescript are able to infer types better and so would require fewer changes to the .hera file. Should we update TypeScript or is it important/helpful to be on a later version so that generated parsers don't have to be on the latest TypeScript version?