### PR TITLE
Feature: @transpile block

### DIFF
--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -1,6 +1,11 @@
 // Compile a rules json to typescript
 
-import type { HeraAST, HeraRules, StructuralHandling } from ./hera-types.civet
+{
+  TranspileSymbol,
+  type HeraAST,
+  type HeraRules
+  type StructuralHandling
+} from ./hera-types.civet
 
 export type CompilerOptions = {
   filename?: string
@@ -10,6 +15,7 @@ export type CompilerOptions = {
   types?: boolean
   libPath?: string | undefined
   module?: boolean
+  transpileFn?: (code: string, filename?: string) => string
 }
 
 strDefs: string[] := []
@@ -166,9 +172,13 @@ compileHandler := (variableName: string,options: CompilerOptions, arg: HeraAST, 
     if h and typeof h is "object" and "f" in h // function mapping
       parser := compileOp(arg, name, false, options.types)
 
+      handlerFunctionSource := options.transpileFn ? options.transpileFn(h.f, options.filename) : h.f
+      if typeof handlerFunctionSource !== "string"
+        throw new Error "@transpile function must return a string"
+
       handler :=
         $loc: h.$loc
-        token: h.f
+        token: handlerFunctionSource
         offset: 4
 
       /* c8 ignore next */
@@ -326,6 +336,12 @@ export function compile(rules: HeraRules, maybeOptions?: CompilerOptions): strin
   /* c8 ignore next */
   libPath := options.libPath or defaultOptions.libPath
   ruleNames := Object.keys(rules)
+
+  if transpileFnSource := rules[TranspileSymbol]
+    fn := eval(`(() => { ${transpileFnSource} })()`)
+    if typeof fn !== "function"
+      throw new Error `@transpile must return a function but got ${typeof fn}`
+    options.transpileFn = fn as (code: string, filename?: string) => string
 
   body := ruleNames.flatMap (name) ->
     [ compileRule(options, name, rules[name]), "\n\n"]

--- a/source/hera-types.civet
+++ b/source/hera-types.civet
@@ -34,8 +34,10 @@ export type PrimaryNode = TerminalNode | SequenceNode | NameNode
 export type HeraAST = PrefixNode | SuffixNode | SequenceNode | TerminalNode | NameNode | string
 
 export const CodeSymbol = Symbol.for("code")
+export const TranspileSymbol = Symbol.for("transpile")
 
 export type HeraRules = {
   [key: string]: HeraAST,
   [CodeSymbol]?: string
+  [TranspileSymbol]?: string
 }

--- a/source/hera.hera
+++ b/source/hera.hera
@@ -1,16 +1,32 @@
 Grammar
   Statement* ->
     const code = $1.filter(a => typeof a === "string")
+
+    const [transpileBlock, ...moreTranspileBlocks] =
+      $1
+        .filter(a => a && typeof a === 'object' && 'transpile' in a)
+        .map(a => a.transpile)
+    if (moreTranspileBlocks.length) throw new Error("@transpile can only be used once")
+
     const rules = Object.fromEntries($1.filter(a => Array.isArray(a)))
     rules[Symbol.for("code")] = code
+    rules[Symbol.for("transpile")] = transpileBlock
     return rules
 
 Statement
+  EOS? TranspilCodeBlock -> $2
   EOS? CodeBlock -> $2
   EOS? Rule -> $2
 
 CodeBlock
   TripleBacktick CodeBody TripleBacktick -> $2
+
+TranspilCodeBlock
+  "@transpile" EOS TranspileCodeBlockBodyLine+ ->
+    return { transpile: $3.join("").trimEnd() }
+
+TranspileCodeBlockBodyLine
+  Indent $( [^\n\r]* NonCommentEOS ) -> $2
 
 Rule
   Name EOS RuleBody -> [$1, $3]

--- a/test/main.civet
+++ b/test/main.civet
@@ -693,6 +693,91 @@ describe "Hera", ->
 
     assert parse ""
 
+  describe "@transpile", ->
+    it "should transpile code", ->
+      {parse} := generate """
+        @transpile
+          return (code) => code.toLowerCase()
+
+        Rule
+          /.+/:a ->
+            RETURN `HELLO ${A}`
+      """
+
+      assert.deepEqual parse("world"), "hello world"
+
+    it "should have access to filename", ->
+      {parse} := generate """
+        @transpile
+          return function addFilenameVariable(code, filename) {
+            return `
+              const $TRANSPILED_FILENAME = ${JSON.stringify(filename)};
+              ${code}
+            `
+          }
+
+        Rule
+          "aaa" ->
+            return { str: $1, file: $TRANSPILED_FILENAME }
+      """
+
+      assert.deepEqual parse("aaa"), { str: "aaa", file: "anonymous" }
+
+    it "should throw an error when transpile function doesn't return a string", ->
+      assert.throws
+        -> generate """
+          @transpile
+            return function badTranspile(code, filename) {
+              return undefined
+            }
+
+          Rule
+            "aaa" ->
+              return $1
+        """
+        /must return a string/
+
+    it "should throw an error when @transpile block doesn't return a function", ->
+      assert.throws
+        -> generate """
+          @transpile
+            // forget to return the function
+            function transpile(code) { return code }
+
+          Rule
+            "aaa" ->
+              return $1
+        """
+        /must return a function/
+
+    it "should eval the transpile function source only once", ->
+      // @ts-ignore
+      globalThis.counts = { definedTranspileFn: 0, transpileHandler: 0 }
+
+      { parse } := generate """
+        @transpile
+          // increment every time this @transpile code block is eval'd
+          globalThis.counts.definedTranspileFn++
+
+          return (code) => {
+            // increment every time a handler is transpiled
+            globalThis.counts.transpileHandler++
+            return code.toLowerCase()
+          }
+
+        Rule
+          "a" ->
+            RETURN "ALPHA"
+          "b" ->
+            RETURN "BRAVO"
+      """
+
+      // @ts-ignore
+      assert.deepEqual globalThis.counts, { definedTranspileFn: 1, transpileHandler: 2 }
+
+      // sanity check: the parser correcly utilizes the @transpile function
+      assert.deepEqual parse("a"), "alpha"
+
   describe "named parameters", ->
     it "should provide named parameters for a sequence", ->
       {parse} := generate """

--- a/test/main.civet
+++ b/test/main.civet
@@ -778,6 +778,25 @@ describe "Hera", ->
       // sanity check: the parser correcly utilizes the @transpile function
       assert.deepEqual parse("a"), "alpha"
 
+    it "should be able to use Civet", ->
+      // Would use `require` but this is an ESM module
+      globalThis.civet = await import "@danielx/civet"
+
+      {parse} := generate """
+        @transpile
+          const { compile } = civet
+          return (code) => compile(
+            `return do\\n${code.replace(/^/gm, '  ')}`,
+            { sync: true }
+          )
+
+        Rule
+          /.+/ ->
+            $0 |> .toUpperCase()
+      """
+
+      assert.deepEqual parse("a"), "A"
+
   describe "named parameters", ->
     it "should provide named parameters for a sequence", ->
       {parse} := generate """


### PR DESCRIPTION
Works like this:

```pegjs
@transpile
  const { compile } = require('@danielx/civet')

  // return a function that will be used to transpile handler functions
  return (code, filename) => compile(
    // puts the handler code inside a `return do ...` block then compiles it
    `return do\\n${code.replace(/^/gm, '  ')}`,
    { sync: true, filename }
  )

Rule
  /.+/ ->
    // use your pre-transpiled language
    $0 |> .toUpperCase()
```

Currently does not support async. In Node.js that will be ok because `require` is sync. Civet and esbuild both have sync versions of compile/transform.

## TODO:
- [ ] support transpilation "target" so that it can compile to JS or TS depending on the context
- [ ] apply the transpile to code blocks (code in triple backticks)

## Questions
- What are the security concerns around having the LSP execute arbitrary code when a .hera file is opened?
- The `@transpile` block can only be synchronous right now. Does that work for the scenarios this needs to  support? 