### PR TITLE
`loader` flag for esbuild plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 node_modules/
 source/machine.js
 parsers/
+tmp/

--- a/build/compile
+++ b/build/compile
@@ -31,11 +31,16 @@ for f in dist/**/*.civet.d.ts; do
   # replace all .civet imports with .js
   sed_i 's/\.civet"/.js"/g' "$f"
 
+  # rename all .civet.d.ts files to .d.ts
   mv "$f" "${f%.civet.d.ts}.d.ts"
 done
 
 # hack to rewrite require extension
-sed_i -e 's/main.civet/main.js/' dist/hera
+# adjust .js files
+for f in dist/**/*.js dist/hera; do
+  # replace all .civet imports with .js
+  sed_i 's/\.civet"/.js"/g' "$f"
+done
 
 # hack to remove import_meta and just use existing require
 sed_i -e '/import_meta/d' -e '/import_module/d' -e 's/require2/require/' dist/main.js

--- a/build/esbuild.civet
+++ b/build/esbuild.civet
@@ -54,4 +54,9 @@ esbuild.build {
     civetPlugin
       ts: "civet"
   ]
+  footer: {
+    // Rewrite default export as CJS exports object
+    // so require('esbuild-plugin') provides the plugin as the default export
+    js: 'module.exports = module.exports.default;'
+  }
 }

--- a/esbuild-example/build-and-use-example.cjs
+++ b/esbuild-example/build-and-use-example.cjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+// A smoke test to make sure the built esbuild plugin works and is exported correctly.
+// This script requires the project to be built (i.e. `yarn build`).
+
+// Import the built plugin
+const { heraPlugin } = require("@danielx/hera/esbuild-plugin");
+
+const { join, resolve } = require("node:path");
+const fs = require("node:fs");
+const esbuild = require("esbuild");
+
+const tmpDir = resolve(__dirname, "../tmp/esbuild-plugin-testing");
+
+fs.rmSync(tmpDir, { recursive: true, force: true });
+
+esbuild
+  .build({
+    entryPoints: ["test.js"],
+    absWorkingDir: __dirname,
+    bundle: true,
+    format: "cjs",
+    platform: "node",
+    outdir: tmpDir,
+    plugins: [heraPlugin({ loader: "ts" })],
+  })
+  .then(() => {
+    const testModulePath = join(tmpDir, "test.js");
+    const { test } = require(testModulePath);
+    test();
+    console.log("ok");
+  });

--- a/esbuild-example/build-and-use-example.cjs
+++ b/esbuild-example/build-and-use-example.cjs
@@ -1,10 +1,8 @@
-#!/usr/bin/env node
-
 // A smoke test to make sure the built esbuild plugin works and is exported correctly.
 // This script requires the project to be built (i.e. `yarn build`).
 
 // Import the built plugin
-const { heraPlugin } = require("@danielx/hera/esbuild-plugin");
+const heraPlugin = require("@danielx/hera/esbuild-plugin");
 
 const { join, resolve } = require("node:path");
 const fs = require("node:fs");

--- a/esbuild-example/grammar.hera
+++ b/esbuild-example/grammar.hera
@@ -1,0 +1,3 @@
+Rule
+  "a" ->
+    return "ok"

--- a/esbuild-example/grammar.ts.hera
+++ b/esbuild-example/grammar.ts.hera
@@ -1,0 +1,3 @@
+Rule
+  "a" ->
+    return "ok" as string

--- a/esbuild-example/test-import.mjs
+++ b/esbuild-example/test-import.mjs
@@ -1,0 +1,3 @@
+import heraPlugin from "@danielx/hera/esbuild-plugin";
+import assert from "node:assert";
+assert.equal(typeof heraPlugin, "function");

--- a/esbuild-example/test-require.cjs
+++ b/esbuild-example/test-require.cjs
@@ -1,0 +1,3 @@
+const heraPlugin = require("@danielx/hera/esbuild-plugin")
+const assert = require("node:assert");
+assert.equal(typeof heraPlugin, "function");

--- a/esbuild-example/test.js
+++ b/esbuild-example/test.js
@@ -1,0 +1,10 @@
+import assert from "node:assert";
+
+import { parse as untypedParse } from "./grammar.hera";
+import { parse as typedParse } from "./grammar.ts.hera";
+
+// validate that both parsers compiled correctly
+export function test() {
+  assert.equal(untypedParse("a"), "ok");
+  assert.equal(typedParse("a"), "ok");
+}

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "benchmark": "NODE_OPTIONS='--require=./node_modules/@danielx/hera/register' civet ./perf/benchmark.civet",
     "build": "bash build/compile",
     "test": "c8 mocha && yarn test:typed-parser-samples && yarn test:esbuild-plugin",
-    "test:esbuild-plugin": "./esbuild-example/build-and-use-example.cjs",
+    "test:esbuild-plugin": "cd ./esbuild-example && node ./build-and-use-example.cjs && node ./test-import.mjs && node ./test-require.cjs",
     "test:typed-parser-samples": "build/typed-parser-samples && tsc -p tsconfig.parsers.json"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "prepublishOnly": "yarn build && yarn test",
     "benchmark": "NODE_OPTIONS='--require=./node_modules/@danielx/hera/register' civet ./perf/benchmark.civet",
     "build": "bash build/compile",
-    "test": "c8 mocha && yarn test:typed-parser-samples",
+    "test": "c8 mocha && yarn test:typed-parser-samples && yarn test:esbuild-plugin",
+    "test:esbuild-plugin": "./esbuild-example/build-and-use-example.cjs",
     "test:typed-parser-samples": "build/typed-parser-samples && tsc -p tsconfig.parsers.json"
   },
   "bin": {

--- a/source/esbuild-plugin.civet
+++ b/source/esbuild-plugin.civet
@@ -1,19 +1,21 @@
-{ readFile } := require 'fs/promises'
-path := require 'path'
-{ compile } := require "./main.js"
+{ readFile } from node:fs/promises
+{ relative } from node:path
+{ compile } from ./main.civet
+type { CompilerOptions } from ./compiler.civet
+type { Plugin, Loader } from esbuild
 
-module.exports = (options) =>
+export interface HeraPluginOptions < CompilerOptions
+  loader?: Loader
+
+export function heraPlugin({ loader, ...heraOptions }: HeraPluginOptions = {}): Plugin
   name: 'hera'
   setup: (build) =>
-    build.onLoad { filter: /.\.hera$/ }, (args) ->
-      readFile(args.path, 'utf8')
-      .then (source) =>
-        filename := path.relative(process.cwd(), args.path)
+    build.onLoad { filter: /.\.hera$/ }, ({ path }) =>
+      filename := relative(process.cwd(), path)
 
-        return {
-          contents: compile source, { ...options, filename }
-        }
-      .catch (e) =>
-        errors: [{
-          text: e.message
-        }]
+      readFile(path, 'utf8')
+        |> await
+        |> compile ., { ...heraOptions, filename }
+        |> { contents: & }
+        // only set the loader if it's provided; don't set it to undefined
+        |> (load) => loader ? { ...load, loader } : load

--- a/source/esbuild-plugin.civet
+++ b/source/esbuild-plugin.civet
@@ -7,7 +7,7 @@ type { Plugin, Loader } from esbuild
 export interface HeraPluginOptions < CompilerOptions
   loader?: Loader
 
-export function heraPlugin({ loader, ...heraOptions }: HeraPluginOptions = {}): Plugin
+export default function heraPlugin({ loader, ...heraOptions }: HeraPluginOptions = {}): Plugin
   name: 'hera'
   setup: (build) =>
     build.onLoad { filter: /.\.hera$/ }, ({ path }) =>

--- a/test/esbuild-plugin.civet
+++ b/test/esbuild-plugin.civet
@@ -2,7 +2,7 @@ assert from assert
 { writeFileSync, mkdirSync, rmSync } from node:fs
 path from node:path
 esbuild, { type BuildOptions } from esbuild
-{ heraPlugin } from ../source/esbuild-plugin.civet
+heraPlugin from ../source/esbuild-plugin.civet
 type { HeraPluginOptions } from ../source/esbuild-plugin.civet
 
 describe "esbuild plugin", ->

--- a/test/esbuild-plugin.civet
+++ b/test/esbuild-plugin.civet
@@ -1,0 +1,106 @@
+assert from assert
+{ writeFileSync, mkdirSync, rmSync } from node:fs
+path from node:path
+esbuild, { type BuildOptions } from esbuild
+{ heraPlugin } from ../source/esbuild-plugin.civet
+type { HeraPluginOptions } from ../source/esbuild-plugin.civet
+
+describe "esbuild plugin", ->
+  tmpDir := path.join 'tmp', 'esbuild-plugin-testing'
+
+  function buildAndImport(
+    basename: string
+    source: string
+    {
+      pluginOptions
+      esbuildOptions
+    }: {
+      pluginOptions?: HeraPluginOptions
+      esbuildOptions?: BuildOptions
+    } = {}
+  )
+    sourceFile := path.join tmpDir, basename
+    jsFile := path.join tmpDir, `${path.parse(basename).name}.js`
+
+    writeFileSync sourceFile, source
+
+    await esbuild.build {
+      entryPoints: [sourceFile]
+      outfile: jsFile
+      bundle: true
+      format: 'cjs'
+      plugins: [
+        heraPlugin(pluginOptions)
+      ]
+      ...esbuildOptions
+    }
+
+    import(`../${jsFile}`)
+
+
+  @beforeAll ->
+    rmSync tmpDir, recursive: true, force: true
+    mkdirSync tmpDir, recursive: true
+
+  it "should transform untyped grammars", ->
+    { parse } := await buildAndImport 'simple-grammar.hera', """
+      Rule
+        "a" ->
+          return "ok"
+    """
+
+    assert.equal parse('a'), "ok"
+
+
+  it "should transform typed grammars by allowing the loader to be specified", ->
+    { parse } := await buildAndImport 'simple-typed-grammar.hera',
+      """
+        Rule
+          "a" ->
+            return "ok" as string
+      """
+      pluginOptions: { loader: 'ts' }
+
+    assert.equal parse('a'), "ok"
+
+
+  it "should transform imported untyped grammars", ->
+    { parse } := await buildAndImport 'math-example.ts', """
+      import { parse } from '../../samples/math.hera' // relative to the generated parser file
+      export { parse }
+    """
+
+    assert.equal parse('8 + 3 / 7'), 8 + 3 / 7
+
+
+  it "should transform imported typed grammars by allowing the loader to be specified", ->
+    writeFileSync path.join(tmpDir, 'imported-typed-grammar.hera'), """
+      Rule
+        "a" ->
+          return "ok" as string
+    """
+
+    { parse } := await buildAndImport 'use-typed-grammar.ts',
+      """
+        import { parse } from './imported-typed-grammar.hera' // relative to the generated parser file
+        export { parse }
+      """
+      pluginOptions: { loader: 'ts' }
+
+    assert.equal parse('a'), "ok"
+
+
+  it "should throw an error when parsting fails", ->
+    writeFileSync path.join(tmpDir, 'bad-grammar.hera'), """
+      THIS GRAMMAR SHOULD NOT COMPILE
+    """
+
+    await assert.rejects
+      =>
+        await buildAndImport 'bad-example.ts',
+          """
+            import './bad-grammar.hera' // relative to the generated parser file
+          """
+          esbuildOptions: { logLevel: 'silent' }
+
+      /Failed to parse/


### PR DESCRIPTION
## Adds a `loader` flag to the esbuild plugin.
This flag can be used to tell esbuild that once a .hera file is compiled it should be treated as a .ts file (or whatever you want) and continue to be processed by loaders.

e.g.
```ts
esbuild.build({
  ...
  heraPlugin({ loader: "ts" })
})
```

## ~~Stops using default export (❗️API change)~~
~~I couldn't figure out how to get the default export working in both CJS and ESM (e.g. the mocha test suite)~~

## Also
- add mocha tests for the esbuild plugin
- add smoke test (`yarn test:esbuild-plugin`) that ensure the esbuild plugin is built and exported correctly
- rewrite .js files' imports from .civet to .js. Previously this was only applied to .civet.d.ts iles and ./dist/hera