### PR TITLE
Depend on published version of Hera 0.8.17

### DIFF
--- a/build/esbuild.civet
+++ b/build/esbuild.civet
@@ -1,7 +1,7 @@
 esbuild from esbuild
 civetPlugin from @danielx/civet/esbuild
 //@ts-expect-error
-heraPlugin from @danielx/hera-previous/esbuild-plugin.js
+heraPlugin from @danielx/hera-previous/esbuild
 
 watch := process.argv.includes '--watch'
 minify := process.argv.includes '--minify'

--- a/build/esbuild.civet
+++ b/build/esbuild.civet
@@ -1,7 +1,7 @@
 esbuild from esbuild
 civetPlugin from @danielx/civet/esbuild
 //@ts-expect-error
-heraPlugin from ../node_modules/@danielx/hera/esbuild-plugin.js
+heraPlugin from @danielx/hera-previous/esbuild-plugin.js
 
 watch := process.argv.includes '--watch'
 minify := process.argv.includes '--minify'

--- a/build/typed-parser-samples
+++ b/build/typed-parser-samples
@@ -4,7 +4,7 @@ shopt -s globstar
 
 cd "$(dirname "$0")/.."
 
-export NODE_OPTIONS='--require=@danielx/hera-previous/register'
+export NODE_OPTIONS='--import=@danielx/hera-previous/register'
 export PATH="$PWD/node_modules/.bin:$PATH"
 
 rm -rf ./parsers

--- a/build/typed-parser-samples
+++ b/build/typed-parser-samples
@@ -4,7 +4,7 @@ shopt -s globstar
 
 cd "$(dirname "$0")/.."
 
-export NODE_OPTIONS='--require=./node_modules/@danielx/hera/register'
+export NODE_OPTIONS='--require=@danielx/hera-previous/register'
 export PATH="$PWD/node_modules/.bin:$PATH"
 
 rm -rf ./parsers

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@danielx/hera",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "description": "Small and fast parsing expression grammars",
   "devDependencies": {
     "@danielx/civet": "0.10.2",
-    "@danielx/hera-previous": "npm:@danielx/hera@0.8.16",
+    "@danielx/hera-previous": "npm:@danielx/hera@0.8.17",
     "@types/mocha": "^10.0.1",
     "@types/node": "^20.5.6",
     "benchmark": "^2.1.4",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Small and fast parsing expression grammars",
   "devDependencies": {
     "@danielx/civet": "0.10.2",
-    "@danielx/hera": "0.8.16",
+    "@danielx/hera-previous": "npm:@danielx/hera@0.8.16",
     "@types/mocha": "^10.0.1",
     "@types/node": "^20.5.6",
     "benchmark": "^2.1.4",
@@ -25,7 +25,7 @@
       "civet"
     ],
     "require": [
-      "./node_modules/@danielx/hera/register",
+      "@danielx/hera-previous/register",
       "@danielx/civet/register"
     ],
     "reporter": "dot",
@@ -55,7 +55,7 @@
   },
   "scripts": {
     "prepublishOnly": "yarn build && yarn test",
-    "benchmark": "NODE_OPTIONS='--require=./node_modules/@danielx/hera/register' civet ./perf/benchmark.civet",
+    "benchmark": "NODE_OPTIONS='--require=@danielx/hera-previous/register' civet ./perf/benchmark.civet",
     "build": "bash build/compile",
     "test": "c8 mocha && yarn test:typed-parser-samples && yarn test:esbuild-plugin && yarn test:loaders",
     "test:esbuild-plugin": "cd ./esbuild-example && node ./build-and-use-example.cjs && node ./test-import.mjs && node ./test-require.cjs",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "scripts": {
     "prepublishOnly": "yarn build && yarn test",
-    "benchmark": "NODE_OPTIONS='--require=@danielx/hera-previous/register' civet ./perf/benchmark.civet",
+    "benchmark": "NODE_OPTIONS='--import=@danielx/hera-previous/register' civet ./perf/benchmark.civet",
     "build": "bash build/compile",
     "test": "c8 mocha && yarn test:typed-parser-samples && yarn test:esbuild-plugin && yarn test:loaders",
     "test:esbuild-plugin": "cd ./esbuild-example && node ./build-and-use-example.cjs && node ./test-import.mjs && node ./test-require.cjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,7 +23,7 @@
     "@typescript/vfs" "^1.6.0"
     unplugin "^2.2.1"
 
-"@danielx/hera@0.8.16":
+"@danielx/hera-previous@npm:@danielx/hera@0.8.16":
   version "0.8.16"
   resolved "https://registry.yarnpkg.com/@danielx/hera/-/hera-0.8.16.tgz#1f29b1dd8b30a28de9a138175f0b06e380684f6c"
   integrity sha512-AtHz8SHqxXfF67cTgoTV9vT4jVsdhg0OyzL/iNk0mPajfKRVn8hQX8xYuqQwUnaOkoG1XrZcCKp8cZpAMy/34Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     "@typescript/vfs" "^1.6.0"
     unplugin "^2.2.1"
 
-"@danielx/hera-previous@npm:@danielx/hera@0.8.16":
-  version "0.8.16"
-  resolved "https://registry.yarnpkg.com/@danielx/hera/-/hera-0.8.16.tgz#1f29b1dd8b30a28de9a138175f0b06e380684f6c"
-  integrity sha512-AtHz8SHqxXfF67cTgoTV9vT4jVsdhg0OyzL/iNk0mPajfKRVn8hQX8xYuqQwUnaOkoG1XrZcCKp8cZpAMy/34Q==
+"@danielx/hera-previous@npm:@danielx/hera@0.8.17":
+  version "0.8.17"
+  resolved "https://registry.yarnpkg.com/@danielx/hera/-/hera-0.8.17.tgz#43adbfcc0148be79b9e45c5242936993942d9d19"
+  integrity sha512-K6gA1xU0MRi5ftWE5KLodOF+st8x6RBCPgbLacctRPlbZ5racYkeBo17A0/t+Ot4GEfoIkioTuTnpSeSBEtM0g==
 
 "@esbuild/android-arm@0.15.13":
   version "0.15.13"


### PR DESCRIPTION
This PR updates the the depended-on version of Hera to 0.8.17.

- use the exported @danielx/hera/esbuild module instead of /esbuilt-plugin.js
- use `--import` instead of `--require` when using the ESM loader (which now complains if you try to `--require` it)
- use an alias for the dev-dependency on itself. It makes it more clear when we are using a previous version of Hera and also allows us to use exported modules instead of having to importing the source file from the package's directory.

We could also use a different name than `@danielx/hera-previous`, e.g.:
- `@published/hera`
- `hera-from-npm`
- `hera-legacy`
- `boostrapped-hera`