### PR TITLE
Publish script: create and push git tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ on:
     branches: [main]
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 jobs:

--- a/build/autorelease.sh
+++ b/build/autorelease.sh
@@ -27,4 +27,12 @@ else
   fi
   # npm publish performs OIDC trusted publishing on GitHub Actions; pnpm does not.
   npm publish --access public "${TAG_ARGS[@]}"
+
+  GIT_TAG="v$LOCAL"
+  if git ls-remote --exit-code --tags origin "refs/tags/$GIT_TAG" >/dev/null 2>&1; then
+    echo "Tag $GIT_TAG already exists on origin; skipping tag creation."
+  else
+    git tag "$GIT_TAG"
+    git push origin "$GIT_TAG"
+  fi
 fi

--- a/build/autorelease.sh
+++ b/build/autorelease.sh
@@ -16,8 +16,10 @@ LOCAL=$(node -p "require('./package.json').version")
 
 echo "Checking $NAME@$LOCAL"
 
+GIT_TAG="v$LOCAL"
+
 if npm view "$NAME@$LOCAL" version >/dev/null 2>&1; then
-  echo "Skip: this version is already on npm."
+  echo "Skip publish: $NAME@$LOCAL already on npm."
 else
   TAG_ARGS=()
   # Semver: drop +build, then '-' means prerelease (e.g. 1.0.0-rc.1); 1.0.0+meta is stable.
@@ -27,12 +29,13 @@ else
   fi
   # npm publish performs OIDC trusted publishing on GitHub Actions; pnpm does not.
   npm publish --access public "${TAG_ARGS[@]}"
+fi
 
-  GIT_TAG="v$LOCAL"
-  if git ls-remote --exit-code --tags origin "refs/tags/$GIT_TAG" >/dev/null 2>&1; then
-    echo "Tag $GIT_TAG already exists on origin; skipping tag creation."
-  else
-    git tag "$GIT_TAG"
-    git push origin "$GIT_TAG"
-  fi
+# Tag independently so a transient tag-push failure can recover on the next run,
+# instead of leaving a published version permanently untagged.
+if git ls-remote --exit-code --tags origin "refs/tags/$GIT_TAG" >/dev/null 2>&1; then
+  echo "Skip tag: $GIT_TAG already exists on origin."
+else
+  git tag "$GIT_TAG"
+  git push origin "$GIT_TAG"
 fi


### PR DESCRIPTION
`build/autorelease.sh` creates and pushes a `v<version>` tag after a successful npm publish. Tag check uses `git ls-remote` (authoritative, works on shallow CI checkouts). Publish and tag run independently so a transient tag-push failure can recover on the next run. Workflow granted `contents: write` so `GITHUB_TOKEN` can push the tag.