### PR TITLE
Infer AST types from grammar rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to `@danielx/hera` will be documented in this file.
 
+## Unreleased
+
+### Changed
+- Rules without an explicit `::Type` are no longer emitted with a
+  `MaybeResult<any>` return annotation.  TypeScript now infers the
+  precise return type from the rule body, so consumers can read the AST
+  shape via `ReturnType<typeof Rule>` (#73).
+- **Migration note**: grammars with mutual recursion (e.g.
+  `Expression → Primary → Expression`) now need a single `::Type`
+  annotation somewhere in the cycle to break TypeScript's circular
+  inference.  `::any -> $1` works as a minimal pass-through; using a
+  more specific type gives consumers tighter inference.  Without the
+  annotation, `tsc --types` reports `implicitly has return type 'any'`
+  on the cyclic rule(s).
+- Grammar authors who want literal-type discriminators (e.g.
+  `type: "Block"` rather than `type: string`) can now write
+  `type: "Block" as const` in the handler return — the IIFE's inferred
+  return type flows out as the rule's return type.
+
 ## [0.9.2] - 2026-04-26
 
 ### Fixed

--- a/build/typed-parser-samples
+++ b/build/typed-parser-samples
@@ -32,3 +32,11 @@ compile_parser samples/math.hera
 compile_parser samples/named-params.hera
 compile_parser samples/unary-subtract.hera
 compile_parser samples/types.hera
+
+# Acceptance test for AST type inference (issue #73): compiles in `module`
+# mode with `language=civet` so the consumer's `import { Mini } from
+# './inference.fixture.hera'` resolves, and copies the test-d.ts authoring
+# file into parsers/ so tsc -p tsconfig.parsers.json checks them together.
+civet source/cli.civet --types --module --language civet --libPath ./machine.js \
+  < test/inference.fixture.hera > parsers/inference.fixture.hera.tsx
+cp test/inference.test-d.ts parsers/inference.test-d.ts

--- a/samples/coffee.hera
+++ b/samples/coffee.hera
@@ -15,7 +15,7 @@ Content
   Expression
 
 Expression
-  Applied
+  Applied ::any
 
 # Function application:
 # a b

--- a/samples/coffee.hera
+++ b/samples/coffee.hera
@@ -15,7 +15,7 @@ Content
   Expression
 
 Expression
-  Applied ::any
+  Applied ::any -> $1
 
 # Function application:
 # a b

--- a/samples/regex.hera
+++ b/samples/regex.hera
@@ -7,9 +7,9 @@ RegexCharacter
   EscapeSequence
 
 Primary
-  CharacterClass
-  Group
-  RegexCharacter
+  CharacterClass ::any
+  Group ::any
+  RegexCharacter ::any
 
 Group
   "(" GroupPrefix? Primary* ")"

--- a/samples/regex.hera
+++ b/samples/regex.hera
@@ -7,9 +7,9 @@ RegexCharacter
   EscapeSequence
 
 Primary
-  CharacterClass ::any
-  Group ::any
-  RegexCharacter ::any
+  CharacterClass ::any -> $1
+  Group ::any -> $1
+  RegexCharacter ::any -> $1
 
 Group
   "(" GroupPrefix? Primary* ")"

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -24,6 +24,8 @@ getOptValue := (opt: string) ->
   if index > -1
     process.argv[index + 1]
 
+language := getOptValue('--language') as 'javascript' | 'typescript' | 'civet' | undefined
+
 process.stdout.write compile ast,
   types:     process.argv.includes '--types'
   inlineMap: process.argv.includes '--inlineMap'
@@ -31,6 +33,7 @@ process.stdout.write compile ast,
   filename: filename
   source: input
   libPath: getOptValue('--libPath')
+  language: language
 
 // Write out cli io
 if process.argv.includes '--cli'

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -408,21 +408,19 @@ ${tokenBranch}  const $$loc = $$r.loc, $$value = $$r.value;
   body.push iife
   // Mutate $$r.value in place instead of allocating a fresh ParseResult,
   // saving a heap allocation per successful rule match.  When no explicit
-  // ::Type is present, type $$final and the assigned $$r as
-  // `MaybeResult<typeof $$m>` so the IIFE's inferred return type flows out
-  // as the rule function's return type.  With `::Type`, the original
-  // `MaybeResult<retType>` / `as any` shapes are preserved unchanged.
+  // ::Type is present, annotate $$final as `MaybeResult<typeof $$m>` so the
+  // IIFE's inferred return type flows out as the rule function's return
+  // type.  $$final's annotation does the typing work — the `as any` on the
+  // assignment from $$r is just to bypass the structural mismatch (TS still
+  // believes $$r.value has its old shape pre-mutation).
   finalAnno := if types
     if retType then `: MaybeResult<${retType.trim()}>` else ": MaybeResult<typeof $$m>"
   else ""
-  rValueCast := if types
-    if retType then " as any" else " as unknown as MaybeResult<typeof $$m>"
-  else ""
-  rMutateCast := types ? " as any" : ""
+  rValueCast := types ? " as any" : ""
   body.push `;
   let $$final${finalAnno} = undefined;
   if (($$m${tokenizeCast}) !== SKIP) {
-    ($$r${rMutateCast}).value = $$m;
+    ($$r${rValueCast}).value = $$m;
     $$final = $$r${rValueCast};
   }
   ${exitHook("$$final")}

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -151,7 +151,12 @@ emitEventEnter := (options: CompilerOptions, name: string, retType: string | und
   { types } := options
   // Cast the cache return so the rule function's inferred return type matches
   // `Parser<T>` (i.e. `MaybeResult<T>`), not `unknown` from `ParserContext.enter`.
-  retAnno := if types then ` as MaybeResult<${retType ? retType.trim() : "any"}>` else ""
+  // When no explicit ::Type is present, cast to `never` instead so this branch
+  // contributes nothing to the function's inferred return type — preserving
+  // the precise type inferred from the success path.
+  retAnno := if types
+    if retType then ` as MaybeResult<${retType.trim()}>` else " as never"
+  else ""
   enteredType := if types then ": { cache?: unknown, data?: unknown } | undefined" else ""
   eventDataType := if types then ": unknown" else ""
   ```
@@ -316,6 +321,13 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
   helpers.push `const ${fnName}$parser = ${parserExpr};`
 
   tokenizeCast := types ? " as any" : ""
+  // Tokenize-branch return: when no explicit ::Type, cast to `never` so the
+  // branch doesn't widen the function's inferred return type.  With an
+  // explicit ::Type, the outer return annotation already pins the type, so
+  // keep the existing `as any` (the tokenize value's tuple shape doesn't
+  // overlap with the declared SequenceNode/etc., which would reject a
+  // tighter cast).
+  tokenReturnCast := if types and not retType then " as never" else tokenizeCast
 
   // Per-shape: params, their types (against typeof $$value), and call args.
   // We cache `$$r`'s `loc`/`value` into locals `$$loc`/`$$value` before
@@ -378,10 +390,10 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
     const $$tok${tokTokenType} = $$r;
     $$tok.value = { type: ${nameLit}, children: [$$r.value].flat(), token: $$state.input.substring($$state.pos, $$r.pos), loc: $$r.loc };
     ${exitHook("$$tok")}
-    return $$tok${tokenizeCast};
+    return $$tok${tokenReturnCast};
   }\n`
   else
-    `  if ($$ctx.tokenize) return $$r${tokenizeCast};\n`
+    `  if ($$ctx.tokenize) return $$r${tokenReturnCast};\n`
 
   body := []
   if wrapEvent
@@ -417,10 +429,12 @@ compileRule := (options: CompilerOptions, name: string, rule: HeraAST) ->
 
   if not isTopChoice
     retType := ruleReturnType(rule)
-    // Always annotate return type in TS mode so recursive rules (e.g. expression
-    // grammars where rules reference each other) don't fall back to `unknown`
-    // during TS's circular-inference resolution.
-    retAnno := if types then `: MaybeResult<${retType ? retType.trim() : "any"}>` else ""
+    // Annotate the rule function's return type only when an explicit ::Type is
+    // present.  Without it, leave the function unannotated so TS infers the
+    // precise return type from the body — consumers can then read the AST
+    // shape via `ReturnType<typeof Rule>`.  An explicit ::Type still anchors
+    // the inference so recursive rules don't fall back to `unknown`.
+    retAnno := if types and retType then `: MaybeResult<${retType.trim()}>` else ""
     { helpers, body } := compileRuleBodyInline(options, name, name, rule, true)
     return [
       ...helpers.flatMap((h) -> [h, "\n\n"])
@@ -445,12 +459,27 @@ compileRule := (options: CompilerOptions, name: string, rule: HeraAST) ->
     ]
 
   retType := ruleReturnType(rule)
-  retAnno := if types then `: MaybeResult<${retType ? retType.trim() : "any"}>` else ""
+  // Same as the non-choice branch: only emit a return annotation when an
+  // explicit ::Type is known (or every alternative is annotated, per
+  // ruleReturnType).  Otherwise let TS infer the union from the body.
+  retAnno := if types and retType then `: MaybeResult<${retType.trim()}>` else ""
 
-  // In TS mode, widen $$final's declared type so successive alternatives
-  // (which may return unrelated literal types, e.g. "+" vs "-") don't collide
-  // on the let binding's inferred narrow type.
-  finalWideDecl := if types then `: MaybeResult<${retType ? retType.trim() : "any"}>` else ""
+  // Declare $$final at a union type so successive alternatives (which may
+  // return unrelated literal types) don't collide on a let binding's narrow
+  // type.  With an explicit ::Type, use it directly.  Without one, build
+  // `MaybeResult<Unwrap<ReturnType<typeof X$0>> | ...>` from each
+  // alternative — Unwrap strips the ParseResult wrapper so the union is on
+  // the inner value types, which lets TS keep `Parser<T>` inference clean
+  // when the rule is used inside `$S(...)` etc.  A bare `??` chain produces
+  // `MaybeResult<X> | MaybeResult<Y>` which TS does not normalize to
+  // `MaybeResult<X | Y>`, breaking that downstream inference.
+  finalWideDecl := if types
+    if retType
+      `: MaybeResult<${retType.trim()}>`
+    else
+      altUnion := args.map((_, i) -> `Unwrap<ReturnType<typeof ${name}$${i}>>`).join(" | ")
+      `: MaybeResult<${altUnion}>`
+  else ""
   tryBlock := args.map (_, i) ->
     if i is 0
       `  let $$final${finalWideDecl} = ${name}$${i}($$ctx, $$state);\n`
@@ -730,10 +759,11 @@ tsHead := mjsHead.replace("}", """
   type ParserContext,
   type ParserOptions,
   type ParseState,
+  type Unwrap,
 }
 """) +
   "\nvoid " + mjsHead.match(/\{[\s\S]+\}/m)![0] + // quick-and-dirty way to void all the imports so that TS doesn't complain if they aren't used
-  "\n// Reference all imported types at value-position so TS doesn't flag them as unused.\nconst _types: Loc | MaybeResult<any> | ParseResult<any> | Parser<any> | ParserContext | ParserOptions<any> | ParseState | undefined = undefined; void _types;\n"
+  "\n// Reference all imported types at value-position so TS doesn't flag them as unused.\nconst _types: Loc | MaybeResult<any> | ParseResult<any> | Parser<any> | ParserContext | ParserOptions<any> | ParseState | Unwrap<MaybeResult<any>> | undefined = undefined; void _types;\n"
 
 
 tsTail := """

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -407,14 +407,23 @@ ${tokenBranch}  const $$loc = $$r.loc, $$value = $$r.value;
   const $$m = `
   body.push iife
   // Mutate $$r.value in place instead of allocating a fresh ParseResult,
-  // saving a heap allocation per successful rule match.
-  finalAnno := if types then `: MaybeResult<${retType ? retType.trim() : "any"}>` else ""
-  rValueCast := types ? " as any" : ""
+  // saving a heap allocation per successful rule match.  When no explicit
+  // ::Type is present, type $$final and the assigned $$r as
+  // `MaybeResult<typeof $$m>` so the IIFE's inferred return type flows out
+  // as the rule function's return type.  With `::Type`, the original
+  // `MaybeResult<retType>` / `as any` shapes are preserved unchanged.
+  finalAnno := if types
+    if retType then `: MaybeResult<${retType.trim()}>` else ": MaybeResult<typeof $$m>"
+  else ""
+  rValueCast := if types
+    if retType then " as any" else " as unknown as MaybeResult<typeof $$m>"
+  else ""
+  rMutateCast := types ? " as any" : ""
   body.push `;
   let $$final${finalAnno} = undefined;
   if (($$m${tokenizeCast}) !== SKIP) {
-    ($$r${rValueCast}).value = $$m;
-    $$final = $$r${tokenizeCast};
+    ($$r${rMutateCast}).value = $$m;
+    $$final = $$r${rValueCast};
   }
   ${exitHook("$$final")}
   return $$final;`

--- a/test/inference.fixture.hera
+++ b/test/inference.fixture.hera
@@ -1,0 +1,16 @@
+Mini
+  Block
+  Num
+
+Block
+  "{" Num "}" -> {
+    type: "Block" as const,
+    children: $0,
+  }
+
+Num
+  /[0-9]+/ -> {
+    type: "Num" as const,
+    value: parseInt($1),
+    children: [$1],
+  }

--- a/test/inference.test-d.ts
+++ b/test/inference.test-d.ts
@@ -1,0 +1,28 @@
+import { Mini, Block, Num } from "./inference.fixture.hera"
+
+// 1. The rule's return type carries the inferred AST shape.
+type MiniValue = NonNullable<ReturnType<typeof Mini>>["value"]
+type BlockValue = NonNullable<ReturnType<typeof Block>>["value"]
+type NumValue = NonNullable<ReturnType<typeof Num>>["value"]
+
+// 2. Discriminator literals survive inference.
+const blockType: "Block" = (null as unknown as BlockValue).type
+const numType: "Num" = (null as unknown as NumValue).type
+void blockType, numType
+
+// 3. Mini is the union of its alternatives.
+const m = null as unknown as MiniValue
+if (m.type === "Block") {
+  const c: unknown[] = m.children   // narrowed to Block
+  void c
+} else {
+  const v: number = m.value         // narrowed to Num
+  void v
+}
+
+// 4. Cross-arm field access is rejected.
+const wrong = m.type === "Block"
+  // @ts-expect-error — Block has no `value` field
+  ? m.value
+  : null
+void wrong

--- a/test/inference.test-d.ts
+++ b/test/inference.test-d.ts
@@ -1,28 +1,28 @@
 import { Mini, Block, Num } from "./inference.fixture.hera"
 
-// 1. The rule's return type carries the inferred AST shape.
+// Type-level assertion helpers, mirroring the core of TypeStrong/ts-expect.
+const expectType = <T>(_: T): void => void 0
+type TypeEqual<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true : false
+
 type MiniValue = NonNullable<ReturnType<typeof Mini>>["value"]
 type BlockValue = NonNullable<ReturnType<typeof Block>>["value"]
 type NumValue = NonNullable<ReturnType<typeof Num>>["value"]
 
-// 2. Discriminator literals survive inference.
-const blockType: "Block" = (null as unknown as BlockValue).type
-const numType: "Num" = (null as unknown as NumValue).type
-void blockType, numType
+// Discriminator literals survive inference (not widened to `string`).
+expectType<"Block">((null as unknown as BlockValue).type)
+expectType<"Num">((null as unknown as NumValue).type)
 
-// 3. Mini is the union of its alternatives.
-const m = null as unknown as MiniValue
+// Mini is exactly the union of its alternatives' value types.
+expectType<TypeEqual<MiniValue, BlockValue | NumValue>>(true)
+
+// Discriminated narrowing: each branch only sees its own fields.
+declare const m: MiniValue
 if (m.type === "Block") {
-  const c: unknown[] = m.children   // narrowed to Block
-  void c
-} else {
-  const v: number = m.value         // narrowed to Num
-  void v
-}
-
-// 4. Cross-arm field access is rejected.
-const wrong = m.type === "Block"
+  expectType<unknown[]>(m.children)
   // @ts-expect-error — Block has no `value` field
-  ? m.value
-  : null
-void wrong
+  m.value
+} else {
+  expectType<number>(m.value)
+}

--- a/test/main.civet
+++ b/test/main.civet
@@ -162,10 +162,12 @@ describe "Hera", ->
     parser := generate grammar
     assert.equal parser.parse("x"), 42
 
-    // With `types: true`, the annotation should flow into the emitted
-    // rule's return type so recursive grammars don't fall back to `unknown`.
+    // With `types: true`: this is a top-level choice where only one
+    // alternative carries a `::Type`, so no rule-level annotation is emitted
+    // (TS infers the union from the body via `??` chaining instead).
     code := compile grammar, types: true
-    assert.match code, /function Rule\(\$\$ctx: ParserContext, \$\$state: ParseState\): MaybeResult<any>/
+    assert.match code, /function Rule\(\$\$ctx: ParserContext, \$\$state: ParseState\) \{/
+    assert.doesNotMatch code, /function Rule\(\$\$ctx: ParserContext, \$\$state: ParseState\): MaybeResult/
 
   it "should compile multi-line inline handler bodies", ->
     // Regression: an inline handler body that spans multiple lines

--- a/tsconfig.parsers.json
+++ b/tsconfig.parsers.json
@@ -12,7 +12,7 @@
     // "allowImportingTsExtensions": true,
     "target": "es6", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [ "ES2020", "DOM" ], /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    // "jsx": "preserve",                                   /* Specify what JSX code is generated. */
+    "jsx": "preserve",                                   /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
     // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h' */


### PR DESCRIPTION
Closes #73 
## Summary
- Drop the `: MaybeResult<any>` rule-function annotation when no `::Type` is given so consumers can read the AST shape via `ReturnType<typeof Rule>`.
- Top-level choice rules: declare `$$final` as a typed union built from each alternative's `Unwrap<ReturnType<typeof X$N>>` (a bare `??` chain produces `MaybeResult<A> | MaybeResult<B>` which TS does not normalise to `MaybeResult<A | B>` when matching `Parser<T>` in $S/$C call sites).
- Cast cache-hit and tokenize-branch returns to `never` (instead of `any`) when no `::Type` is present, so those branches don't widen the inferred return type.
- Internal `$$final`/`$$r` flow: type `$$final` as `MaybeResult<typeof $$m>` and cast the `$$r` assignment through `unknown` to the same type, so the IIFE's inferred return flows out as the rule function's return.
- `samples/regex.hera` and `samples/coffee.hera` each break a real reference cycle (Primary↔Group; Expression→…→Primary→Expression) with a single `::any` annotation on a rule in the cycle.
- Rules with explicit `::Type` annotations are unchanged in emit.

## Acceptance test (from the issue)
Added `test/inference.fixture.hera` + `test/inference.test-d.ts`.  Wired into `pnpm test:typed-parser-samples` via `build/typed-parser-samples`: the fixture is compiled in `module` + `civet` mode, the test-d.ts is copied into `parsers/`, and `tsc -p tsconfig.parsers.json` checks them together (tsconfig now sets `\"jsx\": \"preserve\"` for the `.tsx` output).  The CLI gained a `--language` flag for this.

The fixture writes `type: \"Block\" as const` / `type: \"Num\" as const` — literal preservation is the grammar author's responsibility (matching the same \"single well-placed annotation\" principle used to break recursion cycles).

## Test plan
- [x] `pnpm test` — 118 mocha + typed-parser-samples + esbuild-plugin + loaders all pass
- [x] Acceptance test (`tsc -p tsconfig.parsers.json`) reports zero diagnostics for the inference fixture + test-d.ts
- [x] Coffee/regex/math/types/url/hera samples that previously relied on `MaybeResult<any>` pass with the new emit (math/types/url/hera worked once the inner cast leak was fixed; coffee/regex needed an `::any` on the cycle entry point)

🤖 Generated with [Claude Code](https://claude.com/claude-code)