### PR TITLE
Fix return value for type-annotation-only handler with no sequence

### DIFF
--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -290,6 +290,11 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
   // surfaces the declared type onto the rule function signature.
   typeOnlyHandler := rule.length is 3 and rule[2] and ("t" in rule[2]) and not ("f" in rule[2])
   if rule.length !== 3 or typeOnlyHandler
+    // `Choice` wraps a rule with a type-only handler in a sequence ("S"),
+    // which will wrap the result in an array.
+    // Avoid this array wrapper if the length is 1, like the no-handler case.
+    if typeOnlyHandler and rule[0] is "S" and rule[1].length is 1
+      rule = rule[1][0]
     parserExpr := compileOp(rule, name, true, types)
     helpers.push `const ${fnName}$parser = ${parserExpr};`
     body := if wrapEvent

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -269,6 +269,18 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
 
   helpers: any[] := []
 
+  // Unwrap type-annotation-only handlers (`Name ::Type` without `->`)
+  // where rule[2] carries a `t` but no `f`.  `ruleReturnType` already
+  // surfaces the declared type onto the rule function signature.
+  if rule.length is 3 and rule[2] <? "object" and "t" in rule[2] and "f" not in rule[2]
+    // `Choice` wraps a rule with a type-only handler in a sequence ("S"),
+    // which will wrap the result in an array.
+    // Avoid this array wrapper if the length is 1, like the no-handler case.
+    if rule[0] is "S" and rule[1]# is 1
+      rule = rule[1][0]
+    else
+      rule = rule[<2] as HeraAST
+
   // Reference to another rule. This branch only fires for top-level rules
   // (wrapEvent=true); choice-alternative string references are short-circuited
   // in compileRule directly, before we get here.
@@ -283,18 +295,9 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
       ]
     }
 
-  // No handler: return the parser's result verbatim.  Two shapes land
-  // here: (a) `rule.length === 2`, no handler slot at all, and (b) the
-  // type-annotation-only form (`Name ::Type` without `->`) where rule[2]
-  // carries a `t` but no `f`.  In the latter case `ruleReturnType` already
-  // surfaces the declared type onto the rule function signature.
-  typeOnlyHandler := rule.length is 3 and rule[2] and ("t" in rule[2]) and not ("f" in rule[2])
-  if rule.length !== 3 or typeOnlyHandler
-    // `Choice` wraps a rule with a type-only handler in a sequence ("S"),
-    // which will wrap the result in an array.
-    // Avoid this array wrapper if the length is 1, like the no-handler case.
-    if typeOnlyHandler and rule[0] is "S" and rule[1].length is 1
-      rule = rule[1][0]
+  // No handler: return the parser's result verbatim.  This case includes
+  // type-annotation-only handlers which have already been removed.
+  if rule.length !== 3
     parserExpr := compileOp(rule, name, true, types)
     helpers.push `const ${fnName}$parser = ${parserExpr};`
     body := if wrapEvent

--- a/test/main.civet
+++ b/test/main.civet
@@ -157,6 +157,18 @@ describe "Hera", ->
     """
     assert.equal parser.parse("x"), "value"
 
+  it "should keep a typed sequence's default return value", ->
+    parser := generate """
+      Rule
+        A B ::[string, string]
+
+      A
+        "a"
+      B
+        "b"
+    """
+    assert.deepEqual parser.parse("ab"), ["a", "b"]
+
   it "should allow a type annotation with no handler followed by comment", ->
     grammar := """
       Rule

--- a/test/main.civet
+++ b/test/main.civet
@@ -147,6 +147,16 @@ describe "Hera", ->
     code := compile grammar, types: true
     assert.match code, /function Rule\(\$\$ctx: ParserContext, \$\$state: ParseState\): MaybeResult<any>/
 
+  it "should keep a single typed expression's default return value", ->
+    parser := generate """
+      Rule
+        Inner ::string
+
+      Inner
+        "x" -> "value"
+    """
+    assert.equal parser.parse("x"), "value"
+
   it "should allow a type annotation with no handler followed by comment", ->
     grammar := """
       Rule


### PR DESCRIPTION
The new `Foo ::Type` (with no `->` handler) behaved differently from a lone `Foo` when `Foo` is not a sequence (e.g. just a rule name). This is because we add an artificial sequence (`"S"`) wrapper to add the type annotation.

The first commit fixes this in the obvious way.

The second commit offers what I think is a cleaner approach to type-annotation-only handlers: strip them at the beginning, given that the return type is already computed.