### PR TITLE
Speed up typed-parser-samples by batching CLI invocations

### DIFF
--- a/build/typed-parser-samples
+++ b/build/typed-parser-samples
@@ -10,10 +10,6 @@ export PATH="$PWD/node_modules/.bin:$PATH"
 rm -rf ./parsers
 mkdir -p ./parsers
 
-function compile_parser() {
-  civet source/cli.civet --types --libPath ./machine.js < "$1" > "parsers/$(basename "$1").ts"
-}
-
 # hera.hera depends on hera-types.civet which depends on machine.civet.
 # Copy the built machine artifacts into parsers/ so the generated parsers
 # (and the compiled hera-types.ts) can resolve `./machine.js` against
@@ -21,22 +17,23 @@ function compile_parser() {
 cp dist/machine.js parsers/machine.js
 cp dist/machine.d.ts parsers/machine.d.ts
 civet --civet 'rewriteCivetImports=.js' --compile source/hera-types.civet --output parsers/hera-types.ts
-compile_parser source/hera.hera
 
-compile_parser samples/code.hera
-compile_parser samples/regex.hera
-compile_parser samples/url.hera
-compile_parser samples/coffee.hera
-compile_parser samples/structural-mapping.hera
-compile_parser samples/math.hera
-compile_parser samples/named-params.hera
-compile_parser samples/unary-subtract.hera
-compile_parser samples/types.hera
+# Compile all parser samples and the inference fixture in a single CLI
+# invocation to amortize node + civet loader startup over all inputs.
+# `--module` is required for the inference fixture (issue #73): its paired
+# inference.test-d.ts uses `import { Mini } from './inference.fixture.hera'`
+# which only resolves against ES exports.
+civet source/cli.civet --types --module --libPath ./machine.js -o parsers \
+  source/hera.hera \
+  samples/code.hera \
+  samples/regex.hera \
+  samples/url.hera \
+  samples/coffee.hera \
+  samples/structural-mapping.hera \
+  samples/math.hera \
+  samples/named-params.hera \
+  samples/unary-subtract.hera \
+  samples/types.hera \
+  test/inference.fixture.hera
 
-# Acceptance test for AST type inference (issue #73): compiles in `module`
-# mode with `language=civet` so the consumer's `import { Mini } from
-# './inference.fixture.hera'` resolves, and copies the test-d.ts authoring
-# file into parsers/ so tsc -p tsconfig.parsers.json checks them together.
-civet source/cli.civet --types --module --language civet --libPath ./machine.js \
-  < test/inference.fixture.hera > parsers/inference.fixture.hera.tsx
 cp test/inference.test-d.ts parsers/inference.test-d.ts

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -3,50 +3,84 @@
 { compile, parse, grammarToEBNF } from ./main.civet
 encoding := "utf8"
 fs from fs
+path from path
 
-input := fs.readFileSync process.stdin.fd, encoding
-ast := parse input
+argv := process.argv
+valueFlags := new Set ['--language', '--libPath', '-o', '--output']
 
-if process.argv.includes '--ast'
-  process.stdout.write JSON.stringify(ast, null, 2)
-  process.exit 0
-
-if process.argv.includes '--ebnf'
-  process.stdout.write grammarToEBNF(ast)
-  process.exit 0
-
-filename .= "<stdin>"
-try
-  filename = fs.realpathSync '/dev/stdin'
+positional: string[] := []
+i .= 2
+while i < argv.length
+  arg := argv[i]
+  if valueFlags.has arg
+    i += 2
+  else if arg.startsWith '-'
+    i += 1
+  else
+    positional.push arg
+    i += 1
 
 getOptValue := (opt: string) ->
-  index := process.argv.indexOf opt
+  index := argv.indexOf opt
   if index > -1
-    process.argv[index + 1]
+    argv[index + 1]
 
 language := getOptValue('--language') as 'javascript' | 'typescript' | 'civet' | undefined
+outputDir := getOptValue('-o') ?? getOptValue('--output')
 
-process.stdout.write compile ast,
-  types:     process.argv.includes '--types'
-  inlineMap: process.argv.includes '--inlineMap'
-  module:    process.argv.includes '--module'
-  filename: filename
-  source: input
-  libPath: getOptValue('--libPath')
-  language: language
-
-// Write out cli io
-if process.argv.includes '--cli'
-  process.stdout.write """
+cliPostscript := """
 
 
-    if (require.main === module) {
-      const encoding = "utf8"
-      const fs = require("fs")
+  if (require.main === module) {
+    const encoding = "utf8"
+    const fs = require("fs")
 
-      const input = fs.readFileSync(process.stdin.fd, encoding)
-      const ast = parse(input)
+    const input = fs.readFileSync(process.stdin.fd, encoding)
+    const ast = parse(input)
 
-      process.stdout.write(JSON.stringify(ast, null, 2))
-    }
-  """
+    process.stdout.write(JSON.stringify(ast, null, 2))
+  }
+"""
+
+processInput := (input: string, filename: string) ->
+  ast := parse input
+
+  if argv.includes '--ast'
+    return JSON.stringify(ast, null, 2)
+
+  if argv.includes '--ebnf'
+    return grammarToEBNF(ast)
+
+  result .= compile ast,
+    types:     argv.includes '--types'
+    inlineMap: argv.includes '--inlineMap'
+    module:    argv.includes '--module'
+    filename: filename
+    source: input
+    libPath: getOptValue('--libPath')
+    language: language
+
+  if argv.includes '--cli'
+    result += cliPostscript
+
+  result
+
+if positional.length > 0
+  unless outputDir
+    process.stderr.write "Error: -o/--output DIR is required when input files are provided\n"
+    process.exit 1
+  fs.mkdirSync outputDir, { recursive: true }
+  for file of positional
+    src := fs.readFileSync file, encoding
+    realPath .= file
+    try
+      realPath = fs.realpathSync file
+    out := processInput src, realPath
+    target := path.join outputDir, `${ path.basename file }.ts`
+    fs.writeFileSync target, out
+else
+  input := fs.readFileSync process.stdin.fd, encoding
+  filename .= "<stdin>"
+  try
+    filename = fs.realpathSync '/dev/stdin'
+  process.stdout.write processInput(input, filename)


### PR DESCRIPTION
Add multi-file + -o/--output mode to source/cli.civet so the typed-parser-samples test compiles all 11 hera files in one node+civet startup instead of 11. Drops end-to-end pnpm test:typed-parser-samples from ~16s to ~3.3s (4.9×).

The samples now compile in --module mode alongside the inference fixture; this trades typecheck coverage of the cjs head/tail templates (static strings) for the unification.