### PR TITLE
Optimize handler IIFE arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 All notable changes to `@danielx/hera` will be documented in this file.
 
-## Unreleased
+## [0.9.3] - 2026-04-26
+
+### Fixed
+- Type-annotation-only rules now preserve the wrapped parser result shape when
+  the rule is not a sequence, so `Foo ::Type` behaves like `Foo` instead of
+  introducing an array wrapper (#77).
 
 ### Changed
 - Rules without an explicit `::Type` are no longer emitted with a
@@ -20,6 +25,13 @@ All notable changes to `@danielx/hera` will be documented in this file.
   `type: "Block"` rather than `type: string`) can now write
   `type: "Block" as const` in the handler return — the IIFE's inferred
   return type flows out as the rule's return type.
+
+### Performance
+- Generated handler IIFEs now omit unused positional arguments, capture `$skip`
+  from a module-scope constant, pass named `:foo` parts as direct parameters,
+  and only cache `$$value` when retained handler arguments need it.  This
+  reduces generated parser size while keeping parse throughput roughly flat
+  across sample grammars (#79).
 
 ## [0.9.2] - 2026-04-26
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielx/hera",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Small and fast parsing expression grammars",
   "devDependencies": {
     "@danielx/civet": "0.11.6",

--- a/perf/compare.civet
+++ b/perf/compare.civet
@@ -10,9 +10,11 @@ Benchmark from benchmark
 fs from fs
 path from path
 { createRequire } from module
+{ fileURLToPath } from url
 
 require := createRequire(import.meta.url)
-prevHera := require "@danielx/hera-previous/dist/main.js"
+prevRoot := process.env.HERA_PREVIOUS_ROOT ?? "@danielx/hera-previous"
+prevHera := require path.join prevRoot, "dist/main.js"
 currHera := require "../dist/main.js"
 
 // Parse inputs per sample.  Each picked to exercise the grammar meaningfully.
@@ -92,7 +94,7 @@ benchOne := (name, meta) ->
 
 // ---- run -------------------------------------------------------------------
 
-prevVersion := require("@danielx/hera-previous/package.json").version
+prevVersion := require(path.join prevRoot, "package.json").version
 currVersion := require("../package.json").version
 timestamp := new Date().toISOString()
 
@@ -128,7 +130,7 @@ makeRow := (cells) ->
 
 lines := [
   `Hera benchmark: prev vs current (hybrid-compiler)`
-  `  prev: @danielx/hera-previous ${prevVersion}`
+  `  prev: ${prevRoot} ${prevVersion}`
   `  curr: working tree ${currVersion}`
   `  ran:  ${timestamp}`
   ""
@@ -143,4 +145,4 @@ report := lines.join("\n")
 // Print to stdout (so `npm run benchmark` still shows results) and write
 // to perf/report.txt for easy diffing between runs.
 console.log report
-fs.writeFileSync path.join(path.dirname(new URL(import.meta.url).pathname), "report.txt"), report
+fs.writeFileSync path.join(path.dirname(fileURLToPath import.meta.url), "report.txt"), report

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -121,9 +121,15 @@ compileOp := (tuple: HeraAST, name: string, defaultHandler: boolean, types?: boo
 regExpHandlerParams := ["$loc", "$0", "$1", "$2", "$3", "$4", "$5", "$6", "$7", "$8", "$9"]
 regularHandlerParams := ["$loc", "$0", "$1"]
 
+identifierREs := new Map<string, RegExp>()
+
 usesIdentifier := (text: string, identifier: string): boolean ->
-  escaped := identifier.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&")
-  new RegExp(`(?<!\\p{ID_Continue})${escaped}(?!\\p{ID_Continue})`, "u").test text
+  re .= identifierREs.get identifier
+  unless re
+    escaped := identifier.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&")
+    re = new RegExp(`(?<![\\p{ID_Continue}$])${escaped}(?![\\p{ID_Continue}$])`, "u")
+    identifierREs.set identifier, re
+  re.test text
 
 // Compute the declared return type of a rule, if any.
 // For top-level choice: union of sub-rule types (only if all are annotated).
@@ -349,6 +355,9 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
   addNamedParameter := (name: string | undefined, paramType: string, callArg: string) ->
     return unless name
     if parameters.includes(name)
+      /* c8 ignore next 2 */
+      if name.startsWith "$"
+        throw new Error `named parameter "${name}" conflicts with reserved positional parameter`
       throw new Error `duplicate named parameter: ${name}`
     parameters.push name
     paramTypes.push paramType
@@ -356,13 +365,13 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
 
   if rule[0] is "S"
     n := rule[1].length
-    parameters = ["$loc", "$0"].concat rule[1].map (_, i) => `$${i+1}`
+    parameters = ["$loc", "$0"]
     paramTypes = ["Loc", "typeof $$value"]
     callArgs = ["$$r.loc", "$$value"]
-    for (let i = 0; i < n; i++)
+    for i of [0...n]
+      parameters.push `$${i+1}`
       paramTypes.push `typeof $$value[${i}]`
       callArgs.push `$$value[${i}]`
-    for i of [0...n]
       addNamedParameter getNamedVariable(rule[1][i][0]), `typeof $$value[${i}]`, `$$value[${i}]`
   else if rule[0] is "R"
     parameters = regExpHandlerParams.slice()

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -121,6 +121,10 @@ compileOp := (tuple: HeraAST, name: string, defaultHandler: boolean, types?: boo
 regExpHandlerParams := ["$skip", "$loc", "$0", "$1", "$2", "$3", "$4", "$5", "$6", "$7", "$8", "$9"]
 regularHandlerParams := ["$skip", "$loc", "$0", "$1"]
 
+usesIdentifier := (text: string, identifier: string): boolean ->
+  escaped := identifier.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&")
+  new RegExp(`(?<!\\p{ID_Continue})${escaped}(?!\\p{ID_Continue})`, "u").test text
+
 // Compute the declared return type of a rule, if any.
 // For top-level choice: union of sub-rule types (only if all are annotated).
 // For single-body: the handler's h.t.
@@ -373,6 +377,19 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
     callArgs = ["SKIP", "$$loc", "$$value", "$$value"]
     namedParameters = getParameterDeclaration(rule, 0)
 
+  // Only pass the handler parameters that the handler text appears to use.
+  // We use a lexical regex rather than parsing to keep things fast/simple.
+  // Comments and strings will count as usage, but this is mostly harmless
+  // (just reduces optimization).
+  usedParameterIndexes := parameters.flatMap (p, i) ->
+    if usesIdentifier(h.f, p) or usesIdentifier(namedParameters, p)
+      [i]
+    else
+      []
+  parameters = usedParameterIndexes.map (i) -> parameters[i]
+  paramTypes = usedParameterIndexes.map (i) -> paramTypes[i]
+  callArgs = usedParameterIndexes.map (i) -> callArgs[i]
+
   // Emit the IIFE at the rule function's top-level indent (2-space) so the
   // handler body (which comes in at 4-space from the grammar source) is
   // strictly deeper than the IIFE's declaration line — civet's parser
@@ -406,13 +423,18 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
   body := []
   if wrapEvent
     body.push emitEventEnter(options, name, retType)
+  localDeclarations := []
+  if parameters.some (p) -> usesIdentifier(p, "$loc")
+    localDeclarations.push "$$loc = $$r.loc"
+  if callArgs.some (arg) -> usesIdentifier(arg, "$$value")
+    localDeclarations.push "$$value = $$r.value"
+  localLine := if localDeclarations.length then `  const ${localDeclarations.join(", ")};\n` else ""
   body.push `  const $$r = ${fnName}$parser($$ctx, $$state);
   if (!$$r) {
     ${exitHook("undefined")}
     return undefined;
   }
-${tokenBranch}  const $$loc = $$r.loc, $$value = $$r.value;
-  const $$m = `
+${tokenBranch}${localLine}  const $$m = `
   body.push iife
   // Mutate $$r.value in place instead of allocating a fresh ParseResult,
   // saving a heap allocation per successful rule match.  When no explicit

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -341,17 +341,17 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
   // tighter cast).
   tokenReturnCast := if types and not retType then " as never" else tokenizeCast
 
-  // Per-shape: params, their types (against typeof $$value), and call args.
-  // We cache `$$r`'s `loc`/`value` into locals `$$loc`/`$$value` before
-  // building the handler call, so V8 sees direct variable reads instead of
-  // repeated `$$r.loc` / `$$r.value[i]` property lookups each call.
+  // Per-shape: params, their types, and call args.  If any retained arg needs
+  // parser value access, cache `$$r.value` into `$$value` before building the
+  // handler call, so V8 sees direct variable reads instead of repeated
+  // `$$r.value[i]` property lookups.
   let parameters: string[], paramTypes: string[], callArgs: string[], namedParameters: string
   namedParameters = ""
   if rule[0] is "S"
     n := rule[1].length
     parameters = ["$skip", "$loc", "$0"].concat rule[1].map (_, i) => `$${i+1}`
     paramTypes = ["typeof SKIP", "Loc", "typeof $$value"]
-    callArgs = ["SKIP", "$$loc", "$$value"]
+    callArgs = ["SKIP", "$$r.loc", "$$value"]
     for (let i = 0; i < n; i++)
       paramTypes.push `typeof $$value[${i}]`
       callArgs.push `$$value[${i}]`
@@ -367,14 +367,14 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
     // length.  In JS mode the cast is elided — `as any[]` isn't valid JS.
     /* c8 ignore next */
     valueExpr := if types then "($$value as any[])" else "$$value"
-    callArgs = ["SKIP", "$$loc"]
+    callArgs = ["SKIP", "$$r.loc"]
     for (let i = 0; i < 10; i++)
       callArgs.push `${valueExpr}[${i}]`
   else
     parameters = regularHandlerParams.slice()
     // Single-value shape: `$0` and `$1` both bind to the whole parser value.
     paramTypes = ["typeof SKIP", "Loc", "typeof $$value", "typeof $$value"]
-    callArgs = ["SKIP", "$$loc", "$$value", "$$value"]
+    callArgs = ["SKIP", "$$r.loc", "$$value", "$$value"]
     namedParameters = getParameterDeclaration(rule, 0)
 
   // Only pass the handler parameters that the handler text appears to use.
@@ -389,6 +389,7 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
   parameters = usedParameterIndexes.map (i) -> parameters[i]
   paramTypes = usedParameterIndexes.map (i) -> paramTypes[i]
   callArgs = usedParameterIndexes.map (i) -> callArgs[i]
+  valueDecl := if callArgs.some((arg) -> usesIdentifier(arg, "$$value")) then "  const $$value = $$r.value;\n" else ""
 
   // Emit the IIFE at the rule function's top-level indent (2-space) so the
   // handler body (which comes in at 4-space from the grammar source) is
@@ -423,18 +424,12 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
   body := []
   if wrapEvent
     body.push emitEventEnter(options, name, retType)
-  localDeclarations := []
-  if parameters.some (p) -> usesIdentifier(p, "$loc")
-    localDeclarations.push "$$loc = $$r.loc"
-  if callArgs.some (arg) -> usesIdentifier(arg, "$$value")
-    localDeclarations.push "$$value = $$r.value"
-  localLine := if localDeclarations.length then `  const ${localDeclarations.join(", ")};\n` else ""
   body.push `  const $$r = ${fnName}$parser($$ctx, $$state);
   if (!$$r) {
     ${exitHook("undefined")}
     return undefined;
   }
-${tokenBranch}${localLine}  const $$m = `
+${tokenBranch}${valueDecl}  const $$m = `
   body.push iife
   // Mutate $$r.value in place instead of allocating a fresh ParseResult,
   // saving a heap allocation per successful rule match.  When no explicit

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -205,16 +205,14 @@ emitEventExit := (options: CompilerOptions, name: string): string ->
 //
 // `parameters` / `paramTypes` / `callArgs` are parallel arrays: the formal
 // parameter names, their TS types (referencing `typeof $$value[i]`), and the
-// matching argument expressions used to invoke the IIFE.  `namedParameters`
-// is any `var foo = $N;` aliasing the grammar's `:name` markers, emitted at
-// the top of the IIFE body.
+// matching argument expressions used to invoke the IIFE.
 //
 // Civet's indent-sensitive parser is happy as long as the IIFE body sits at
 // a strictly-deeper indent than the IIFE declaration.  We rely on the rule
 // function using early returns for the null/tokenize paths so the IIFE
 // lands at 2-space indent, while the handler body comes in at 4-space from
 // the grammar's source indent.
-emitHandlerIIFE := (options: CompilerOptions, handler: { $loc: any, f: string, t?: string, inline?: boolean }, parameters: string[], paramTypes: string[], callArgs: string[], namedParameters: string, baseIndent: string) ->
+emitHandlerIIFE := (options: CompilerOptions, handler: { $loc: any, f: string, t?: string, inline?: boolean }, parameters: string[], paramTypes: string[], callArgs: string[], baseIndent: string) ->
   { types } := options
   handlerRetAnno := types and handler.t ? `: ${handler.t}` : ""
 
@@ -245,19 +243,20 @@ emitHandlerIIFE := (options: CompilerOptions, handler: { $loc: any, f: string, t
   else
     handlerToken
 
-  // `void $skip, $loc, $0, ...` references every formal parameter so
+  // `void $loc, $0, ...` references generated positional parameters so
   // `noUnusedParameters` is silenced without wrapping the entire IIFE in a
   // `//@ts-ignore` (which would swallow real errors in the handler body).
+  // Named parameters are intentionally left out so TS can still flag them
+  // when the regex usage scan only saw the name in a comment/string.
   // Tried `if (false) { …refs… }` — benchmarked slower: the extra branch
   // isn't free even when always-false, while V8 strips the void-comma
   // expression cleanly once the function is JIT-compiled.
-  voidLine := if types and parameters.length then `${bodyIndent}void ${parameters.join(", ")};\n` else ""
-  namedBlock := namedParameters ? `${bodyIndent}${namedParameters}\n` : ""
+  voidParameters := parameters.filter (p) => p.startsWith "$"
+  voidLine := if types and voidParameters.length then `${bodyIndent}void ${voidParameters.join(", ")};\n` else ""
 
   [
     `(function(${typedParameters.join(", ")})${handlerRetAnno} {\n`
     voidLine
-    namedBlock
     handlerBody
     `\n${baseIndent}})(${callArgs.join(", ")})`
   ]
@@ -345,8 +344,16 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
   // parser value access, cache `$$r.value` into `$$value` before building the
   // handler call, so V8 sees direct variable reads instead of repeated
   // `$$r.value[i]` property lookups.
-  let parameters: string[], paramTypes: string[], callArgs: string[], namedParameters: string
-  namedParameters = ""
+  let parameters: string[], paramTypes: string[], callArgs: string[]
+
+  addNamedParameter := (name: string | undefined, paramType: string, callArg: string) ->
+    return unless name
+    if parameters.includes(name)
+      throw new Error `duplicate named parameter: ${name}`
+    parameters.push name
+    paramTypes.push paramType
+    callArgs.push callArg
+
   if rule[0] is "S"
     n := rule[1].length
     parameters = ["$loc", "$0"].concat rule[1].map (_, i) => `$${i+1}`
@@ -355,8 +362,8 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
     for (let i = 0; i < n; i++)
       paramTypes.push `typeof $$value[${i}]`
       callArgs.push `$$value[${i}]`
-    namedParameters = rule[1].map (node, i) -> getParameterDeclaration(node, i+1)
-    .join("")
+    for i of [0...n]
+      addNamedParameter getNamedVariable(rule[1][i][0]), `typeof $$value[${i}]`, `$$value[${i}]`
   else if rule[0] is "R"
     parameters = regExpHandlerParams.slice()
     // RegExpMatchArray positional typing (and reTupleType short tuples) don't
@@ -375,14 +382,14 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
     // Single-value shape: `$0` and `$1` both bind to the whole parser value.
     paramTypes = ["Loc", "typeof $$value", "typeof $$value"]
     callArgs = ["$$r.loc", "$$value", "$$value"]
-    namedParameters = getParameterDeclaration(rule, 0)
+    addNamedParameter getNamedVariable(rule[0]), "typeof $$value", "$$value"
 
   // Only pass the handler parameters that the handler text appears to use.
   // We use a lexical regex rather than parsing to keep things fast/simple.
   // Comments and strings will count as usage, but this is mostly harmless
   // (just reduces optimization).
   usedParameterIndexes := parameters.flatMap (p, i) ->
-    if usesIdentifier(h.f, p) or usesIdentifier(namedParameters, p)
+    if usesIdentifier(h.f, p)
       [i]
     else
       []
@@ -395,7 +402,7 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
   // handler body (which comes in at 4-space from the grammar source) is
   // strictly deeper than the IIFE's declaration line — civet's parser
   // needs that for block vs object-literal disambiguation.
-  iife := emitHandlerIIFE(options, h, parameters, paramTypes, callArgs, namedParameters, "  ")
+  iife := emitHandlerIIFE(options, h, parameters, paramTypes, callArgs, "  ")
 
   // Compose the rule body with early returns for the null / tokenize /
   // skip paths; all exits route through a single exit-hook helper.  The
@@ -549,18 +556,7 @@ compileExports := (ruleNames: string[], module: boolean) ->
     .join("\n")
 
 /**
-Get a JS declaration string for nodes that have named parameters.
-*/
-getParameterDeclaration := (node: HeraAST, i: number) ->
-  name := getNamedVariable node[0]
-
-  if name
-    `var ${name} = $${i};`
-  else
-    ""
-
-/**
-Get a JS declaration string for nodes that have named parameters.
+Get the named handler parameter, if any, from an operator wrapper.
 */
 getNamedVariable := (op: HeraAST[0]): string | undefined ->
   if typeof op is "object" and "name" in op

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -118,8 +118,8 @@ compileOp := (tuple: HeraAST, name: string, defaultHandler: boolean, types?: boo
 // Only rules have handlers, either one per choice line,
 // or one for the whole deal
 
-regExpHandlerParams := ["$skip", "$loc", "$0", "$1", "$2", "$3", "$4", "$5", "$6", "$7", "$8", "$9"]
-regularHandlerParams := ["$skip", "$loc", "$0", "$1"]
+regExpHandlerParams := ["$loc", "$0", "$1", "$2", "$3", "$4", "$5", "$6", "$7", "$8", "$9"]
+regularHandlerParams := ["$loc", "$0", "$1"]
 
 usesIdentifier := (text: string, identifier: string): boolean ->
   escaped := identifier.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&")
@@ -349,9 +349,9 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
   namedParameters = ""
   if rule[0] is "S"
     n := rule[1].length
-    parameters = ["$skip", "$loc", "$0"].concat rule[1].map (_, i) => `$${i+1}`
-    paramTypes = ["typeof SKIP", "Loc", "typeof $$value"]
-    callArgs = ["SKIP", "$$r.loc", "$$value"]
+    parameters = ["$loc", "$0"].concat rule[1].map (_, i) => `$${i+1}`
+    paramTypes = ["Loc", "typeof $$value"]
+    callArgs = ["$$r.loc", "$$value"]
     for (let i = 0; i < n; i++)
       paramTypes.push `typeof $$value[${i}]`
       callArgs.push `$$value[${i}]`
@@ -361,20 +361,20 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
     parameters = regExpHandlerParams.slice()
     // RegExpMatchArray positional typing (and reTupleType short tuples) don't
     // pass cleanly through .reduce/.filter; keep positional args as `any`.
-    paramTypes = ["typeof SKIP", "Loc"].concat Array(10).fill("any")
+    paramTypes = ["Loc"].concat Array(10).fill("any")
     // In TS mode the positional extraction casts through `any[]` so short
     // tuples (`["a"|"b"]`) don't trip TS2493 at indices beyond the tuple
     // length.  In JS mode the cast is elided — `as any[]` isn't valid JS.
     /* c8 ignore next */
     valueExpr := if types then "($$value as any[])" else "$$value"
-    callArgs = ["SKIP", "$$r.loc"]
+    callArgs = ["$$r.loc"]
     for (let i = 0; i < 10; i++)
       callArgs.push `${valueExpr}[${i}]`
   else
     parameters = regularHandlerParams.slice()
     // Single-value shape: `$0` and `$1` both bind to the whole parser value.
-    paramTypes = ["typeof SKIP", "Loc", "typeof $$value", "typeof $$value"]
-    callArgs = ["SKIP", "$$r.loc", "$$value", "$$value"]
+    paramTypes = ["Loc", "typeof $$value", "typeof $$value"]
+    callArgs = ["$$r.loc", "$$value", "$$value"]
     namedParameters = getParameterDeclaration(rule, 0)
 
   // Only pass the handler parameters that the handler text appears to use.
@@ -629,6 +629,7 @@ export function compile(rules: HeraRules, maybeOptions?: CompilerOptions): strin
     head
     `\n\nconst grammar = ${compileRulesObject(ruleNames)};\n\n`
     `\n\nconst grammarDefaultRule = ${JSON.stringify(ruleNames[0])};\n\n`
+    "const $skip = SKIP; void $skip;\n\n"
     strDefSource
     "\n\n"
     reDefSource

--- a/test/main.civet
+++ b/test/main.civet
@@ -1281,6 +1281,18 @@ describe "Hera", ->
       assert.doesNotMatch result, /\$\$value = \$\$r\.value/
       assert.doesNotMatch result, /void[^;]*\$0;/
 
+    it "should not match internal $$ names as handler parameters", ->
+      grammar := """
+        Rule
+          "a" ->
+            return $$loc
+      """
+      result := compile(parse(grammar), language: 'javascript')
+      assert.match result, /\(function\(\) \{/m
+      assert.match result, /\}\)\(\)/m
+      assert.doesNotMatch result, /\(function\(\$loc/
+      assert.doesNotMatch result, /\}\)\(\$\$r\.loc\)/
+
     it "should cache parser value when value arguments are used", ->
       grammar := """
         Rule

--- a/test/main.civet
+++ b/test/main.civet
@@ -1216,10 +1216,9 @@ describe "Hera", ->
       result := compile(parse(grammar), language: 'javascript')
       assert.match result, /\(function\(\) \{/m
       assert.match result, /\}\)\(\)/m
-      assert.doesNotMatch result, /\$\$loc = \$\$r\.loc/
       assert.doesNotMatch result, /\$\$value = \$\$r\.value/
 
-    it "should omit cached loc when only value arguments are used", ->
+    it "should cache parser value when value arguments are used", ->
       grammar := """
         Rule
           "a" ->
@@ -1229,9 +1228,8 @@ describe "Hera", ->
       assert.match result, /\(function\(\$0\) \{/m
       assert.match result, /\}\)\(\$\$value\)/m
       assert.match result, /\$\$value = \$\$r\.value/
-      assert.doesNotMatch result, /\$\$loc = \$\$r\.loc/
 
-    it "should omit cached loc and value when only $skip is used", ->
+    it "should omit cached value when only $skip is used", ->
       grammar := """
         Rule
           "a" ->
@@ -1240,5 +1238,4 @@ describe "Hera", ->
       result := compile(parse(grammar), language: 'javascript')
       assert.match result, /\(function\(\$skip\) \{/m
       assert.match result, /\}\)\(SKIP\)/m
-      assert.doesNotMatch result, /\$\$loc = \$\$r\.loc/
       assert.doesNotMatch result, /\$\$value = \$\$r\.value/

--- a/test/main.civet
+++ b/test/main.civet
@@ -1010,6 +1010,67 @@ describe "Hera", ->
 
       assert.deepEqual parse("ab"), ["a", "b"]
 
+    it "should emit named parameters directly", ->
+      grammar := """
+        Rule
+          A:a B:b -> a
+
+        A
+          "a"
+
+        B
+          "b"
+      """
+      result := compile(parse(grammar), language: 'javascript')
+      assert.match result, /\(function\(a\) \{/m
+      assert.match result, /\}\)\(\$\$value\[0\]\)/m
+      assert.doesNotMatch result, /var a = \$1/
+
+    it "should not void named parameters", ->
+      grammar := """
+        Rule
+          "a":a -> a
+      """
+      result := compile(parse(grammar), language: 'typescript')
+      assert.match result, /\(function\(a: typeof \$\$value\) \{/m
+      assert.doesNotMatch result, /void[^;]*a;/
+
+    it "should reject duplicate named parameters", ->
+      assert.throws ->
+        compile parse """
+          Rule
+            A:x B:x -> x
+
+          A
+            "a"
+
+          B
+            "b"
+        """
+      , /duplicate named parameter: x/
+
+    it "should reject names reserved for positional parameters", ->
+      assert.throws ->
+        compile parse """
+          Rule
+            "a":$0 -> $0
+        """
+      , /Failed to parse/
+
+      assert.throws ->
+        compile parse """
+          Rule
+            "a":$loc -> $loc
+        """
+      , /Failed to parse/
+
+      assert.throws ->
+        compile parse """
+          Rule
+            "a":$skip -> $skip
+        """
+      , /Failed to parse/
+
     it "should provide named parameters for a single string", ->
       {parse} := generate """
         A
@@ -1152,7 +1213,8 @@ describe "Hera", ->
       // by bodyIndent (4 extra spaces) past the grammar's original indent
       // so downstream indent-sensitive parsers read them as the object
       // body rather than separate statements.
-      assert.match result, /\n    var t = \$0;\n    return \{\n        type: "TypeSuffix",/m
+      assert.match result, /\(function\(t:/m
+      assert.match result, /\n    return \{\n        type: "TypeSuffix",/m
       // The handler IIFE closes with `  })(...)` at 2-space indent.
       assert.match result, /\n  \}\)\(/m
 
@@ -1213,10 +1275,11 @@ describe "Hera", ->
           "a" ->
             return 1
       """
-      result := compile(parse(grammar), language: 'javascript')
+      result := compile(parse(grammar), language: 'typescript')
       assert.match result, /\(function\(\) \{/m
       assert.match result, /\}\)\(\)/m
       assert.doesNotMatch result, /\$\$value = \$\$r\.value/
+      assert.doesNotMatch result, /void[^;]*\$0;/
 
     it "should cache parser value when value arguments are used", ->
       grammar := """
@@ -1224,7 +1287,8 @@ describe "Hera", ->
           "a" ->
             return $0
       """
-      result := compile(parse(grammar), language: 'javascript')
-      assert.match result, /\(function\(\$0\) \{/m
+      result := compile(parse(grammar), language: 'typescript')
+      assert.match result, /\(function\(\$0:/m
       assert.match result, /\}\)\(\$\$value\)/m
       assert.match result, /\$\$value = \$\$r\.value/
+      assert.match result, /void \$0;/

--- a/test/main.civet
+++ b/test/main.civet
@@ -1206,3 +1206,39 @@ describe "Hera", ->
       // so it must not leak into JS output.
       assert.match result, /\$\$value\[1\]/
       assert.doesNotMatch result, /as any\[\]/
+
+    it "should omit unused handler arguments and cached locals", ->
+      grammar := """
+        Rule
+          "a" ->
+            return 1
+      """
+      result := compile(parse(grammar), language: 'javascript')
+      assert.match result, /\(function\(\) \{/m
+      assert.match result, /\}\)\(\)/m
+      assert.doesNotMatch result, /\$\$loc = \$\$r\.loc/
+      assert.doesNotMatch result, /\$\$value = \$\$r\.value/
+
+    it "should omit cached loc when only value arguments are used", ->
+      grammar := """
+        Rule
+          "a" ->
+            return $0
+      """
+      result := compile(parse(grammar), language: 'javascript')
+      assert.match result, /\(function\(\$0\) \{/m
+      assert.match result, /\}\)\(\$\$value\)/m
+      assert.match result, /\$\$value = \$\$r\.value/
+      assert.doesNotMatch result, /\$\$loc = \$\$r\.loc/
+
+    it "should omit cached loc and value when only $skip is used", ->
+      grammar := """
+        Rule
+          "a" ->
+            return $skip
+      """
+      result := compile(parse(grammar), language: 'javascript')
+      assert.match result, /\(function\(\$skip\) \{/m
+      assert.match result, /\}\)\(SKIP\)/m
+      assert.doesNotMatch result, /\$\$loc = \$\$r\.loc/
+      assert.doesNotMatch result, /\$\$value = \$\$r\.value/

--- a/test/main.civet
+++ b/test/main.civet
@@ -1228,14 +1228,3 @@ describe "Hera", ->
       assert.match result, /\(function\(\$0\) \{/m
       assert.match result, /\}\)\(\$\$value\)/m
       assert.match result, /\$\$value = \$\$r\.value/
-
-    it "should omit cached value when only $skip is used", ->
-      grammar := """
-        Rule
-          "a" ->
-            return $skip
-      """
-      result := compile(parse(grammar), language: 'javascript')
-      assert.match result, /\(function\(\$skip\) \{/m
-      assert.match result, /\}\)\(SKIP\)/m
-      assert.doesNotMatch result, /\$\$value = \$\$r\.value/


### PR DESCRIPTION
With the new IIFE rewrite (#69), it opened the door to optimizing generated code in a bunch of new ways:

- Only pass parameters that are actually referenced by handler source text. Currently this is a bit approximate: if the code includes the string `"$1"` or the comment `// $1`, then `$1` will still get passed. But it's still correct, just a bit less optimized. And this way we don't need to parse the code.
- `$skip` is now a module global `const` instead of passing it through every handler IIFE.
- Replace named-parameter `var foo = $i` aliases with direct IIFE parameters, allowing unused positional `$i` args to be dropped when we only used the named form. These parameters don't get `void`ed, so we'll still get warnings about unused variables like before.
- Remove unnecessary `const $$loc = $r.$loc` caching; just pass in `$r.$loc` as an argument.
- Only cache `$$value = $$r.value` when retained handler args need parser value access

## Performance

prev = main branch
curr = this PR

| sample | compile prev | compile curr | compile Δ | parse prev | parse curr | parse Δ | size prev | size curr | size Δ |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| url.hera | 6,592/s | 5,058/s | -23.3% | 400,597/s | 398,485/s | -0.5% | 21,061 | 20,021 | -4.9% |
| math.hera | 15,565/s | 5,350/s | -65.6% | 108,952/s | 109,009/s | +0.1% | 7,139 | 6,868 | -3.8% |
| coffee.hera | 1,653/s | 1,471/s | -11.0% | 40,297/s | 41,384/s | +2.7% | 32,816 | 32,617 | -0.6% |
| regex.hera | 3,991/s | 3,348/s | -16.1% | 373,292/s | 362,908/s | -2.8% | 13,796 | 13,589 | -1.5% |
| hera_v0_8.hera | 856/s | 627/s | -26.7% | 1,722/s | 1,703/s | -1.1% | 67,081 | 63,719 | -5.0% |

Hera compilation got slower, grammar parse times are roughly flat (`+` good, `-` bad), and sizes got a fair amount smaller. I expect memory is better behaved, or at least the stack gets less thrashing.

## Diffs

Here are some sample diffs from `parsers`:

**Unused Handler Args Removed** [`parsers/structural-mapping.hera.ts`]

```ts
// Before
const $$loc = $$r.loc, $$value = $$r.value;
const $$m = (function($skip: typeof SKIP, $loc: Loc, $0: typeof $$value, $1: typeof $$value) {
  void $skip, $loc, $0, $1;
  return 7
})(SKIP, $$loc, $$value, $$value);

// After
const $$m = (function() {
  return 7
})();
```

**Regex Args Trimmed** [`parsers/inference.fixture.hera.tsx`]

```ts
// Before
const $$loc = $$r.loc, $$value = $$r.value;
const $$m = (function($skip: typeof SKIP, $loc: Loc, $0: any, $1: any, $2: any, $3: any, $4: any, $5: any, $6: any, $7: any, $8: any, $9: any) {
  void $skip, $loc, $0, $1, $2, $3, $4, $5, $6, $7, $8, $9;
  return {
      type: "Num" as const,
      value: parseInt($1),
      children: [$1],
    }
})(SKIP, $$loc, ($$value as any[])[0], ($$value as any[])[1], ($$value as any[])[2], ($$value as any[])[3], ($$value as any[])[4], ($$value as any[])[5], ($$value as any[])[6], ($$value as any[])[7], ($$value as any[])[8], ($$value as any[])[9]);

// After
const $$value = $$r.value;
const $$m = (function($1: any) {
  void $1;
  return {
      type: "Num" as const,
      value: parseInt($1),
      children: [$1],
    }
})(($$value as any[])[1]);
```

**Named Parts Become Parameters** [`parsers/unary-subtract.hera.ts`]

```ts
// Before
const $$m = (function($skip: typeof SKIP, $loc: Loc, $0: typeof $$value, $1: typeof $$value[0], $2: typeof $$value[1]) {
  void $skip, $loc, $0, $1, $2;
  var a = $1;var b = $2;
  return a.length - b.length
})(SKIP, $$loc, $$value, $$value[0], $$value[1]);

// After
const $$m = (function(a: typeof $$value[0], b: typeof $$value[1]) {
  return a.length - b.length
})($$value[0], $$value[1]);
```

**`$loc` Passed Directly** [`parsers/hera.hera.ts`]

```ts
// Before
const $$loc = $$r.loc, $$value = $$r.value;
const $$m = (function($skip: typeof SKIP, $loc: Loc, $0: typeof $$value, $1: typeof $$value[0]):  Handler  {
  void $skip, $loc, $0, $1;
  return {
    f: $1.trimEnd(),
    $loc,
    inline: true,
  }
})(SKIP, $$loc, $$value, $$value[0]);

// After
const $$value = $$r.value;
const $$m = (function($loc: Loc, $1: typeof $$value[0]):  Handler  {
  void $loc, $1;
  return {
    f: $1.trimEnd(),
    $loc,
    inline: true,
  }
})($$r.loc, $$value[0]);
```

**Typical Positional Trimming** [`parsers/math.hera.ts`]

```ts
// Before
const $$m = (function($skip: typeof SKIP, $loc: Loc, $0: typeof $$value, $1: typeof $$value[0], $2: typeof $$value[1]): number  {
  void $skip, $loc, $0, $1, $2;
  return $2.reduce(..., $1);
})(SKIP, $$loc, $$value, $$value[0], $$value[1]);

// After
const $$m = (function($1: typeof $$value[0], $2: typeof $$value[1]): number  {
  void $1, $2;
  return $2.reduce(..., $1);
})($$value[0], $$value[1]);
```