### PR TITLE
Enforce 100% coverage with c8 "all": true

### DIFF
--- a/build/esbuild.civet
+++ b/build/esbuild.civet
@@ -34,7 +34,7 @@ buildOrWatch({
 }).catch -> process.exit 1
 
 buildOrWatch({
-  entryPoints: ['source/cli.civet']
+  entryPoints: ['source/cli-bin.civet']
   bundle: false
   format: "cjs"
   sourcemap
@@ -69,6 +69,7 @@ esbuild.build {
 
 esbuild.build {
   entryPoints: [
+    "source/cli.civet"
     "source/esm.civet"
     "source/hera-types.civet"
     "source/machine.civet"

--- a/build/typed-parser-samples
+++ b/build/typed-parser-samples
@@ -23,7 +23,7 @@ civet --civet 'rewriteCivetImports=.js' --compile source/hera-types.civet --outp
 # `--module` is required for the inference fixture (issue #73): its paired
 # inference.test-d.ts uses `import { Mini } from './inference.fixture.hera'`
 # which only resolves against ES exports.
-civet source/cli.civet --types --module --libPath ./machine.js -o parsers \
+civet source/cli-bin.civet --types --module --libPath ./machine.js -o parsers \
   source/hera.hera \
   samples/code.hera \
   samples/regex.hera \

--- a/package.json
+++ b/package.json
@@ -38,20 +38,31 @@
   "c8": {
     "100": true,
     "check-coverage": true,
+    "all": true,
     "reporter": [
       "lcov",
       "text"
     ],
     "extension": [
       ".civet",
-      ".hera",
-      ".mts",
-      ".ts"
+      ".hera"
     ],
     "exclude": [
       "build/",
       "dist/",
-      "test/"
+      "esbuild-example/",
+      "loader-examples/",
+      "lsp/",
+      "parsers/",
+      "perf/",
+      "samples/",
+      "source/cli-bin.civet",
+      "source/hera.hera.d.ts",
+      "source/machine.civet",
+      "source/register.civet",
+      "source/register/",
+      "test/",
+      "tmp/"
     ]
   },
   "scripts": {

--- a/source/cli-bin.civet
+++ b/source/cli-bin.civet
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+fs from fs
+path from path
+{ main } from ./cli.civet
+
+argv := process.argv
+encoding := "utf8"
+valueFlags := new Set ['--language', '--libPath', '-o', '--output']
+
+positional: string[] := []
+i .= 2
+while i < argv.length
+  arg := argv[i]
+  if valueFlags.has arg
+    i += 2
+  else if arg.startsWith '-'
+    i += 1
+  else
+    positional.push arg
+    i += 1
+
+getOptValue := (opt: string) ->
+  index := argv.indexOf opt
+  if index > -1
+    argv[index + 1]
+
+outputDir := getOptValue('-o') ?? getOptValue('--output')
+
+reportError := (err: unknown, file?: string): never ->
+  msg := if err instanceof Error then err.message else String(err)
+  prefix := if file then `${file}: ` else ""
+  process.stderr.write `Error: ${prefix}${msg}\n`
+  process.exit 1
+
+if positional.length > 0
+  unless outputDir
+    process.stderr.write "Error: -o/--output DIR is required when input files are provided\n"
+    process.exit 1
+  fs.mkdirSync outputDir, { recursive: true }
+  for file of positional
+    try
+      src := fs.readFileSync file, encoding
+      realPath .= file
+      try
+        realPath = fs.realpathSync file
+      out := main argv, src, realPath
+      target := path.join outputDir, `${ path.basename file }.ts`
+      fs.writeFileSync target, out
+    catch err
+      reportError err, file
+else
+  try
+    input := fs.readFileSync process.stdin.fd, encoding
+    filename .= "<stdin>"
+    try
+      filename = fs.realpathSync '/dev/stdin'
+    process.stdout.write main argv, input, filename
+  catch err
+    reportError err

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -1,48 +1,7 @@
-#!/usr/bin/env node
-
 { compile, parse, grammarToEBNF } from ./main.civet
-encoding := "utf8"
-fs from fs
-path from path
+type { CompilerOptions } from ./compiler.civet
 
-argv := process.argv
-valueFlags := new Set ['--language', '--libPath', '-o', '--output']
-
-positional: string[] := []
-i .= 2
-while i < argv.length
-  arg := argv[i]
-  if valueFlags.has arg
-    i += 2
-  else if arg.startsWith '-'
-    i += 1
-  else
-    positional.push arg
-    i += 1
-
-getOptValue := (opt: string) ->
-  index := argv.indexOf opt
-  if index > -1
-    argv[index + 1]
-
-language := getOptValue('--language') as 'javascript' | 'typescript' | 'civet' | undefined
-outputDir := getOptValue('-o') ?? getOptValue('--output')
-
-cliPostscript := """
-
-
-  if (require.main === module) {
-    const encoding = "utf8"
-    const fs = require("fs")
-
-    const input = fs.readFileSync(process.stdin.fd, encoding)
-    const ast = parse(input)
-
-    process.stdout.write(JSON.stringify(ast, null, 2))
-  }
-"""
-
-processInput := (input: string, filename: string) ->
+export main := (argv: string[], input: string, filename: string = "<stdin>"): string ->
   ast := parse input
 
   if argv.includes '--ast'
@@ -51,36 +10,39 @@ processInput := (input: string, filename: string) ->
   if argv.includes '--ebnf'
     return grammarToEBNF(ast)
 
-  result .= compile ast,
+  getOptValue := (opt: string) ->
+    index := argv.indexOf opt
+    if index > -1
+      argv[index + 1]
+
+  language := getOptValue('--language') as 'javascript' | 'typescript' | 'civet' | undefined
+
+  options: CompilerOptions := {
     types:     argv.includes '--types'
     inlineMap: argv.includes '--inlineMap'
     module:    argv.includes '--module'
     filename: filename
     source: input
     libPath: getOptValue('--libPath')
-    language: language
+  }
+  if language
+    options.language = language
+
+  output .= compile ast, options
 
   if argv.includes '--cli'
-    result += cliPostscript
+    output += """
 
-  result
 
-if positional.length > 0
-  unless outputDir
-    process.stderr.write "Error: -o/--output DIR is required when input files are provided\n"
-    process.exit 1
-  fs.mkdirSync outputDir, { recursive: true }
-  for file of positional
-    src := fs.readFileSync file, encoding
-    realPath .= file
-    try
-      realPath = fs.realpathSync file
-    out := processInput src, realPath
-    target := path.join outputDir, `${ path.basename file }.ts`
-    fs.writeFileSync target, out
-else
-  input := fs.readFileSync process.stdin.fd, encoding
-  filename .= "<stdin>"
-  try
-    filename = fs.realpathSync '/dev/stdin'
-  process.stdout.write processInput(input, filename)
+      if (require.main === module) {
+        const encoding = "utf8"
+        const fs = require("fs")
+
+        const input = fs.readFileSync(process.stdin.fd, encoding)
+        const ast = parse(input)
+
+        process.stdout.write(JSON.stringify(ast, null, 2))
+      }
+    """
+
+  return output

--- a/source/esm.civet
+++ b/source/esm.civet
@@ -1,6 +1,6 @@
 assert from node:assert
 { fileURLToPath, pathToFileURL } from node:url
-{ ResolveHook, LoadHook } from node:module
+type { ResolveHook, LoadHook } from node:module
 
 { compile } from ./main.civet
 type { CompilerOptions } from ./compiler.civet

--- a/test/cli.civet
+++ b/test/cli.civet
@@ -1,0 +1,41 @@
+assert from assert
+{ main } from ../source/cli.civet
+
+grammar := """
+  Rule
+    "a" ->
+      return "ok"
+
+"""
+
+describe "cli main", ->
+  it "should emit JSON ast with --ast", ->
+    out := main ['node', 'hera', '--ast'], grammar
+    parsed := JSON.parse out
+    assert parsed
+
+  it "should emit EBNF with --ebnf", ->
+    out := main ['node', 'hera', '--ebnf'], grammar
+    assert.match out, /Rule/
+
+  it "should compile to JS by default", ->
+    out := main ['node', 'hera'], grammar
+    assert.match out, /parse/
+    assert.doesNotMatch out, /^if \(require\.main/m
+
+  it "should pass --types/--module/--language through to compile", ->
+    out := main ['node', 'hera', '--types', '--module', '--language', 'typescript'], grammar
+    assert.match out, /parse/
+
+  it "should read --libPath via getOptValue", ->
+    out := main ['node', 'hera', '--libPath', './machine.js'], grammar
+    assert.match out, /\.\/machine\.js/
+
+  it "should append cli io block when --cli is set", ->
+    out := main ['node', 'hera', '--cli'], grammar
+    assert.match out, /if \(require\.main === module\)/
+
+  it "should default the filename argument to <stdin>", ->
+    // Smoke check — main should not throw when filename is omitted.
+    out := main ['node', 'hera'], grammar
+    assert typeof out is 'string'

--- a/test/esm.civet
+++ b/test/esm.civet
@@ -1,0 +1,81 @@
+assert from assert
+{ pathToFileURL } from node:url
+{ initialize, load, resolve } from ../source/esm.civet
+
+describe "esm loader hook", ->
+  // Reset module-level heraOptions before each test so tests don't leak
+  // state into one another. esm.civet's defaults are { module: true }.
+  beforeEach -> initialize {}
+
+  describe "resolve", ->
+    it "should pass through non-.hera specifiers", ->
+      called .= false
+      next := (specifier, context) ->
+        called = true
+        { url: "passthrough://" + specifier, shortCircuit: true }
+      result := resolve "./foo.js", { parentURL: "file:///cwd/" }, next
+      assert called
+      assert.equal result.url, "passthrough://./foo.js"
+
+    it "should resolve .hera specifiers against parentURL with shortCircuit", ->
+      next := -> assert.fail "next() should not be called for .hera"
+      result := resolve "./grammar.hera", { parentURL: "file:///cwd/sub/" }, next
+      assert.equal result.url, "file:///cwd/sub/grammar.hera"
+      assert result.shortCircuit
+
+    it "should fall back to baseURL when parentURL is missing", ->
+      next := -> assert.fail "next() should not be called for .hera"
+      result := resolve "./grammar.hera", {}, next
+      // baseURL = pathToFileURL(process.cwd() + "/").href
+      assert result.url.endsWith "/grammar.hera"
+      assert result.url.startsWith "file://"
+
+  describe "load", ->
+    it "should pass through non-.hera URLs", ->
+      called .= false
+      next := (url, context) ->
+        called = true
+        { source: "passthrough", format: "module", shortCircuit: true }
+      result := await load "file:///x.js", { format: "module" }, next
+      assert called
+      assert.equal result.source, "passthrough"
+
+    it "should throw if URL has the double-registration tag", ->
+      next := -> assert.fail "next() should not be called when tag present"
+      await assert.rejects(
+        => load "file:///x.hera#hera-esm-loader", {}, next
+        /already been registered/
+      )
+
+    it "should compile .hera source returned by next()", ->
+      heraSource := """
+        Rule
+          "a" ->
+            return "ok"
+      """
+      nextCalls .= 0
+      next := (url, context) ->
+        nextCalls++
+        // The hook appends #hera-esm-loader to the URL when calling next()
+        assert url.endsWith '#hera-esm-loader'
+        assert.equal context.format, 'module'
+        { source: heraSource }
+
+      result := await load "file:///grammar.hera", {}, next
+      assert.equal nextCalls, 1
+      assert.equal result.format, "module"
+      assert result.shortCircuit
+      assert.match result.source, /Rule/
+
+    it "should emit commonjs format when initialized with module: false", ->
+      initialize { module: false }
+      next := (url, context) -> { source: 'Rule\n  "a" -> return "ok"\n' }
+      result := await load "file:///g.hera", {}, next
+      assert.equal result.format, "commonjs"
+
+    it "should throw if next() returns no source", ->
+      next := (url, context) -> { source: null }
+      await assert.rejects(
+        => load "file:///g.hera", {}, next
+        /file source was not loaded/
+      )


### PR DESCRIPTION
Track every .civet/.hera file under source/, not just the ones imported during the mocha run. Excludes example/sample/build/lsp trees and three source-only files that can't be covered from mocha:

  source/cli-bin.civet  - shebang wrapper, exercised by typed-parser-samples
  source/hera.hera.d.ts - declaration-only
  source/machine.civet  - compiled to dist/machine.js; tests load the artifact

source/register.civet and source/register/ are also excluded: they call node:module register() against sibling .js paths only present in dist/. Integration-tested via loader-examples.

To bring source/cli.civet under coverage, split into source/cli-bin.civet (the shebang wrapper) and an exported main(argv, input, filename). Add test/cli.civet covering the flag branches in-process. Building the call through emitDeclaration also surfaced a latent type error: language: undefined violates exactOptionalPropertyTypes - assign it conditionally.

source/esm.civet's hooks were unreachable from mocha because the CJS loader indirectly imported the file as ESM, where the runtime imports of ResolveHook/LoadHook from node:module fail (type-only). Mark them type and add test/esm.civet for load/resolve/initialize.