### PR TITLE
Drop sed hack: shim import.meta.url via esbuild inject + define

### DIFF
--- a/build/compile
+++ b/build/compile
@@ -15,9 +15,9 @@ cp dist/machine.js source/machine.js
 # Assumes that the last parameter is the file being modified
 #
 # Usage:
-#   sed_i -e '/import_meta/d' -e '/import_module/d' dist/main.js
+#   sed_i 's/foo/bar/g' file.js
 #     is equivalent to
-#   sed -i '' -e '/import_meta/d' -e '/import_module/d' dist/main.js
+#   sed -i '' 's/foo/bar/g' file.js
 #
 # Why? GNU and BSD sed don't both support -i in the same way.
 # See: https://stackoverflow.com/questions/5694228/sed-in-place-flag-that-works-both-on-mac-bsd-and-linux
@@ -35,9 +35,6 @@ for f in dist/**/*.js dist/**/*.d.ts dist/hera; do
   # replace all .civet imports with .js
   sed_i 's/\.civet"/.js"/g' "$f"
 done
-
-# hack to remove import_meta and just use existing require/__dirname
-sed_i -e '/import_meta/d' -e '/import_module/d' -e 's/require2/require/' -e 's/__dirname2/__dirname/g' dist/main.js
 
 # Mark 'hera' cli as executable
 chmod +x dist/hera

--- a/build/esbuild.civet
+++ b/build/esbuild.civet
@@ -23,6 +23,10 @@ buildOrWatch({
   minify
   platform: 'node'
   outdir: 'dist/'
+  // Shim `import.meta.url` for the CJS bundle.
+  define:
+    'import.meta.url': 'import_meta_url'
+  inject: ['build/import-meta-url.js']
   plugins: [
     heraPlugin
       loader: 'ts'

--- a/build/import-meta-url.js
+++ b/build/import-meta-url.js
@@ -1,0 +1,6 @@
+// Injected by esbuild when bundling main.civet to CJS: every
+// `import.meta.url` reference in the source is rewritten to
+// `import_meta_url` (via `define`), and esbuild pulls in this file's
+// export (via `inject`) so the bundle has a real file URL to feed
+// into createRequire / fileURLToPath. See build/esbuild.civet.
+export var import_meta_url = require("url").pathToFileURL(__filename).href;


### PR DESCRIPTION
## Summary
- Replace the brittle `sed -e '/import_meta/d' ... dist/main.js` post-build with esbuild's documented `inject` + `define` pattern
- Rewrite every `import.meta.url` reference in the CJS bundle to `import_meta_url`, an injected helper that produces a real file URL via `pathToFileURL(__filename).href`
- `source/main.civet` keeps its natural ESM `createRequire(import.meta.url)` and `dirname(fileURLToPath(import.meta.url))` calls

## Test plan
- [x] `pnpm build` — silent (no `empty-import-meta` warning)
- [x] `dist/main.js` contains no `var import_meta = {}` shim and no `createRequire(import_meta.url)` with empty url
- [x] `bash build/test` — 120 tests passing
- [x] Smoke: `echo 'Rule\n  "a" -> return "ok"' | node dist/hera` produces a parser

🤖 Generated with [Claude Code](https://claude.com/claude-code)