### PR TITLE
Fix caching behavior of type-annotation-only handlers

### DIFF
--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -287,6 +287,9 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
   // (wrapEvent=true); choice-alternative string references are short-circuited
   // in compileRule directly, before we get here.
   if typeof rule is "string"
+    /* c8 ignore next 2 */
+    unless wrapEvent
+      throw new Error "unexpected choice-alternative rule reference"
     return {
       helpers
       body: [

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -283,18 +283,6 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
 
   helpers: any[] := []
 
-  // Unwrap type-annotation-only handlers (`Name ::Type` without `->`)
-  // where rule[2] carries a `t` but no `f`.  `ruleReturnType` already
-  // surfaces the declared type onto the rule function signature.
-  if rule.length is 3 and rule[2] <? "object" and "t" in rule[2] and "f" not in rule[2]
-    // `Choice` wraps a rule with a type-only handler in a sequence ("S"),
-    // which will wrap the result in an array.
-    // Avoid this array wrapper if the length is 1, like the no-handler case.
-    if rule[0] is "S" and rule[1]# is 1
-      rule = rule[1][0]
-    else
-      rule = rule[<2] as HeraAST
-
   // Reference to another rule. This branch only fires for top-level rules
   // (wrapEvent=true); choice-alternative string references are short-circuited
   // in compileRule directly, before we get here.
@@ -309,9 +297,18 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
       ]
     }
 
-  // No handler: return the parser's result verbatim.  This case includes
-  // type-annotation-only handlers which have already been removed.
-  if rule.length !== 3
+  // No handler: return the parser's result verbatim.  Two shapes land
+  // here: (a) `rule.length === 2`, no handler slot at all, and (b) the
+  // type-annotation-only form (`Name ::Type` without `->`) where rule[2]
+  // carries a `t` but no `f`.  In the latter case `ruleReturnType` already
+  // surfaces the declared type onto the rule function signature.
+  typeOnlyHandler := rule.length is 3 and rule[2] <? "object" and "t" in rule[2] and "f" not in rule[2]
+  if rule.length !== 3 or typeOnlyHandler
+    // `Choice` wraps a rule reference with a type-only handler in a sequence
+    // ("S"), which will wrap the result in an array.  Avoid this array wrapper
+    // if the length is 1, like the no-handler case.
+    if typeOnlyHandler and rule[0] is "S" and rule[1]# is 1
+      rule = rule[1][0]
     parserExpr := compileOp(rule, name, true, types)
     helpers.push `const ${fnName}$parser = ${parserExpr};`
     body := if wrapEvent

--- a/test/main.civet
+++ b/test/main.civet
@@ -1157,6 +1157,32 @@ describe "Hera", ->
         }, "the data"]
       ]
 
+    it "should not emit parent-rule events from typed choice alternatives", ->
+      {parse} := generate """
+        Rule
+          A ::string
+          B ::string
+
+        A
+          "a"
+        B
+          "b"
+      """
+
+      eventLog: unknown[] := []
+      events :=
+        enter: (rule, state) ->
+          eventLog.push ["enter", rule, state.pos]
+          return undefined
+        exit: (rule, state, result) ->
+          eventLog.push ["exit", rule, state.pos, result?.value]
+
+      assert.equal parse("b", { events }), "b"
+      assert.deepEqual eventLog.filter((event) -> event[1] is "Rule"), [
+        ["enter", "Rule", 0]
+        ["exit", "Rule", 0, "b"]
+      ]
+
   describe "modImport", ->
     it "should generate module", ->
       {parse} := await modImport """


### PR DESCRIPTION
It turns out my simplification for type-annotation-only handlers in the second commit of #77 was wrong: it ended up emitting an exit event for the failed branches even if there was a successful branch later, because of the special handling of `"string"` rules that was intended just for the top level.

This PR reverts that simplification, adds a regression test, and adds a safeguard to prevent this sort of bug in the future.

Sorry it's taken so many iterations to fix type-annotation-only handlers. After each fix got published, I tested embedding into Civet and ran into a bug. This time, I tried linking the fix into Civet and things actually work, so this is hopefully the last time we need to fix it... 🤞 (Except Civet's type errors jumped from 760 to 3666... 😬 )