### PR TITLE
Hera codegen optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `@danielx/hera` will be documented in this file.
 
+## [0.9.6] - 2026-04-30
+
+### Performance
+- Generated parsers are smaller thanks to more compact codegen
+
+### Fixed
+- Generated TypeScript now excludes the `$skip` sentinel from handler result
+  types, matching the runtime behavior where `$skip` turns a rule into a failed
+  match rather than a returned value.
+
+### Changed
+- Internally, `$skip` is now a unique symbol rather than an object sentinel.
+
 ## [0.9.5] - 2026-04-29
 
 ### Changed

--- a/build/typed-parser-samples
+++ b/build/typed-parser-samples
@@ -32,6 +32,7 @@ civet source/cli-bin.civet --types --module --libPath ./machine.js -o parsers \
   samples/structural-mapping.hera \
   samples/math.hera \
   samples/named-params.hera \
+  samples/skip.hera \
   samples/unary-subtract.hera \
   samples/types.hera \
   test/inference.fixture.hera

--- a/build/typed-parser-samples
+++ b/build/typed-parser-samples
@@ -38,3 +38,4 @@ civet source/cli-bin.civet --types --module --libPath ./machine.js -o parsers \
   test/inference.fixture.hera
 
 cp test/inference.test-d.ts parsers/inference.test-d.ts
+cp test/skip.test-d.ts parsers/skip.test-d.ts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danielx/hera",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Small and fast parsing expression grammars",
   "devDependencies": {
     "@danielx/civet": "0.11.6",

--- a/samples/skip.hera
+++ b/samples/skip.hera
@@ -1,0 +1,5 @@
+Rule
+  "a"+:as ->
+    if (as.length % 2) return $skip
+    return "even"
+  "a" -> "one"

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -538,7 +538,7 @@ compileRule := (options: CompilerOptions, name: string, rule: HeraAST) ->
 
 compileRulesObject := (ruleNames: string[]) ->
   meat := ruleNames.map (name) ->
-    `  ${name}: ${name}`
+    `  ${name}`
   .join(",\n")
 
   return `{\n${meat}}`

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -448,20 +448,22 @@ ${valueDecl}  const $$m = `
   body.push iife
   // Mutate $$r.value in place instead of allocating a fresh ParseResult,
   // saving a heap allocation per successful rule match.  When no explicit
-  // ::Type is present, annotate $$final as `MaybeResult<typeof $$m>` so the
+  // ::Type is present, annotate $$final from `typeof $$m` so the
   // IIFE's inferred return type flows out as the rule function's return
   // type.  $$final's annotation does the typing work — the `as any` on the
   // assignment from $$r is just to bypass the structural mismatch (TS still
   // believes $$r.value has its old shape pre-mutation).
-  finalAnno := if types
-    if retType then `: MaybeResult<${retType.trim()}>` else ": MaybeResult<typeof $$m>"
+  finalType := if types
+    `MaybeResult<Exclude<${
+      if retType then retType.trim() else "typeof $$m"
+    }, typeof SKIP>>`
   else ""
   rValueCast := types ? " as any" : ""
   body.push ";\n"
   if handlerUsesSkip
     skipCast := types ? " as any" : ""
     body.push ```
-    \  const $$final${finalAnno} = ${conditionalExpression options,
+    \  const $$final${finalType && `: ${finalType}`} = ${conditionalExpression options,
         `($$m${skipCast}) !== SKIP`
         `(($$r${rValueCast}).value = $$m, $$r${rValueCast})`
         "undefined"
@@ -473,7 +475,7 @@ ${valueDecl}  const $$m = `
     body.push ```
     \  ($$r${rValueCast}).value = $$m;
       ${exitHook("$$r")}
-      return $$r${finalAnno && ` as unknown as ${finalAnno.replace(/^: /, "")}`};
+      return $$r${finalType && ` as unknown as ${finalType}`};
     ```
   return { helpers, body }
 
@@ -649,7 +651,7 @@ export function compile(rules: HeraRules, maybeOptions?: CompilerOptions): strin
     head
     `\n\nconst grammar = ${compileRulesObject(ruleNames)};\n\n`
     `\n\nconst grammarDefaultRule = ${JSON.stringify(ruleNames[0])};\n\n`
-    "const $skip = SKIP; void $skip;\n\n"
+    `const $skip${types ? ": (typeof SKIP)" : ""} = SKIP; void $skip;\n\n`
     strDefSource
     "\n\n"
     reDefSource

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -175,12 +175,10 @@ emitEventEnter := (options: CompilerOptions, name: string, retType: string | und
   retAnno := if types
     if retType then ` as MaybeResult<${retType.trim()}>` else " as never"
   else ""
-  enteredType := if types then ": { cache?: unknown, data?: unknown } | undefined" else ""
-  eventDataType := if types then ": unknown" else ""
   ```
-\  const $$entered${enteredType} = $$ctx.enter?.(${JSON.stringify(name)}, $$state);
+\  const $$entered = $$ctx.enter?.(${JSON.stringify(name)}, $$state);
   if ($$entered && "cache" in $$entered) return $$entered.cache${retAnno};
-  const $$eventData${eventDataType} = $$entered?.data;
+  const $$eventData = $$entered?.data;
   ```
   + "\n"
 

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -277,6 +277,12 @@ emitHandlerIIFE := (options: CompilerOptions, handler: { $loc: any, f: string, t
     `\n${baseIndent}})(${callArgs.join(", ")})`
   ]
 
+conditionalExpression := (options: CompilerOptions, condition: string, consequent: string, alternate: string) =>
+  if options.language is 'civet'
+    `if ${condition} then ${consequent} else ${alternate}`
+  else
+    `${condition} ? ${consequent} : ${alternate}`
+
 // Emit the inline body for one rule (or one choice sub-rule).
 //   wrapEvent=true  — emit $EVENT enter/exit hooks (top-level rule)
 //   wrapEvent=false — plain body (a choice sub-rule is called from the top-level wrapper)
@@ -452,11 +458,11 @@ ${valueDecl}  const $$m = `
   skipCast := types ? " as any" : ""
   rValueCast := types ? " as any" : ""
   body.push `;
-  let $$final${finalAnno} = undefined;
-  if (($$m${skipCast}) !== SKIP) {
-    ($$r${rValueCast}).value = $$m;
-    $$final = $$r${rValueCast};
-  }
+  const $$final${finalAnno} = ${conditionalExpression options,
+    `($$m${skipCast}) !== SKIP`
+    `(($$r${rValueCast}).value = $$m, $$r${rValueCast})`
+    "undefined"
+  };
   ${exitHook("$$final")}
   return $$final;`
   return { helpers, body }

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -178,9 +178,9 @@ emitEventEnter := (options: CompilerOptions, name: string, retType: string | und
   enteredType := if types then ": { cache?: unknown, data?: unknown } | undefined" else ""
   eventDataType := if types then ": unknown" else ""
   ```
-\  const $$entered${enteredType} = $$ctx.enter && $$ctx.enter(${JSON.stringify(name)}, $$state);
+\  const $$entered${enteredType} = $$ctx.enter?.(${JSON.stringify(name)}, $$state);
   if ($$entered && "cache" in $$entered) return $$entered.cache${retAnno};
-  const $$eventData${eventDataType} = $$entered && $$entered.data;
+  const $$eventData${eventDataType} = $$entered?.data;
   ```
   + "\n"
 
@@ -208,7 +208,7 @@ emitEventExit := (options: CompilerOptions, name: string): string ->
   }
   ```
   else ""
-  tokenWrap + `  if ($$ctx.exit) $$ctx.exit(${nameLit}, $$state, $$final, $$eventData);\n`
+  tokenWrap + `  $$ctx.exit?.(${nameLit}, $$state, $$final, $$eventData);\n`
 
 // Emit an inline IIFE that applies the handler to the parser result.
 //
@@ -432,7 +432,7 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
   nameLit := JSON.stringify(name)
   exitHook := (retExpr: string): string ->
     if wrapEvent
-      `if ($$ctx.exit) $$ctx.exit(${nameLit}, $$state, ${retExpr}, $$eventData);`
+      `$$ctx.exit?.(${nameLit}, $$state, ${retExpr}, $$eventData);`
     else
       ""
 

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -357,9 +357,9 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
   parserExpr := compileOp(rule, name, false, types)
   helpers.push `const ${fnName}$parser = ${parserExpr};`
 
-  // Per-shape: params, their types, and call args.  If any retained arg needs
-  // parser value access, cache `$$r.value` into `$$value` before building the
-  // handler call, so V8 sees direct variable reads instead of repeated
+  // Per-shape: params, their types, and call args.  If multiple retained args
+  // need parser value access, cache `$$r.value` into `$$value` before building
+  // the handler call, so V8 sees direct variable reads instead of repeated
   // `$$r.value[i]` property lookups.
   let parameters: string[], paramTypes: string[], callArgs: string[]
 
@@ -417,7 +417,13 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
   parameters = usedParameterIndexes.map (i) -> parameters[i]
   paramTypes = usedParameterIndexes.map (i) -> paramTypes[i]
   callArgs = usedParameterIndexes.map (i) -> callArgs[i]
-  valueDecl := if callArgs.some((arg) -> usesIdentifier(arg, "$$value")) then "  const $$value = $$r.value;\n" else ""
+  valueUseCount := (callArgs.filter usesIdentifier ., "$$value")#
+  valueDecl := if valueUseCount > 1
+    "  const $$value = $$r.value;\n"
+  else
+    paramTypes = paramTypes.map .replace /\$\$value/g, => "$$r.value"
+    callArgs = callArgs.map .replace /\$\$value/g, => "$$r.value"
+    ""
 
   // Emit the IIFE at the rule function's top-level indent (2-space) so the
   // handler body (which comes in at 4-space from the grammar source) is

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -351,8 +351,6 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
   parserExpr := compileOp(rule, name, false, types)
   helpers.push `const ${fnName}$parser = ${parserExpr};`
 
-  skipCast := types ? " as any" : ""
-
   // Per-shape: params, their types, and call args.  If any retained arg needs
   // parser value access, cache `$$r.value` into `$$value` before building the
   // handler call, so V8 sees direct variable reads instead of repeated
@@ -451,6 +449,7 @@ ${valueDecl}  const $$m = `
   finalAnno := if types
     if retType then `: MaybeResult<${retType.trim()}>` else ": MaybeResult<typeof $$m>"
   else ""
+  skipCast := types ? " as any" : ""
   rValueCast := types ? " as any" : ""
   body.push `;
   let $$final${finalAnno} = undefined;
@@ -506,15 +505,13 @@ compileRule := (options: CompilerOptions, name: string, rule: HeraAST) ->
   // ruleReturnType).  Otherwise let TS infer the union from the body.
   retAnno := if types and retType then `: MaybeResult<${retType.trim()}>` else ""
 
-  // Declare $$final at a union type so successive alternatives (which may
-  // return unrelated literal types) don't collide on a let binding's narrow
-  // type.  With an explicit ::Type, use it directly.  Without one, build
+  // Declare $$final at a union type so the `||` chain normalizes to
+  // `MaybeResult<X | Y>` instead of `ParseResult<X> | MaybeResult<Y>`.
+  // With an explicit ::Type, use it directly.  Without one, build
   // `MaybeResult<Unwrap<ReturnType<typeof X$0>> | ...>` from each
   // alternative — Unwrap strips the ParseResult wrapper so the union is on
   // the inner value types, which lets TS keep `Parser<T>` inference clean
-  // when the rule is used inside `$S(...)` etc.  A bare `??` chain produces
-  // `MaybeResult<X> | MaybeResult<Y>` which TS does not normalize to
-  // `MaybeResult<X | Y>`, breaking that downstream inference.
+  // when the rule is used inside `$S(...)` etc.
   finalWideDecl := if types
     if retType
       `: MaybeResult<${retType.trim()}>`
@@ -522,11 +519,11 @@ compileRule := (options: CompilerOptions, name: string, rule: HeraAST) ->
       altUnion := args.map((_, i) -> `Unwrap<ReturnType<typeof ${name}$${i}>>`).join(" | ")
       `: MaybeResult<${altUnion}>`
   else ""
-  tryBlock := args.map (_, i) ->
-    if i is 0
-      `  let $$final${finalWideDecl} = ${name}$${i}($$ctx, $$state);\n`
-    else
-      `  if (!$$final) $$final = ${name}$${i}($$ctx, $$state);\n`
+  tryBlock := [
+    `  const $$final${finalWideDecl} = `
+    args.map((_, i) -> `${name}$${i}($$ctx, $$state)`).join("\n    || ")
+    `;\n`
+  ]
 
   [
     ...allHelpers.flatMap((h) -> [h, "\n\n"])

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -408,6 +408,7 @@ compileRuleBodyInline := (options: CompilerOptions, name: string, fnName: string
   // We use a lexical regex rather than parsing to keep things fast/simple.
   // Comments and strings will count as usage, but this is mostly harmless
   // (just reduces optimization).
+  handlerUsesSkip := usesIdentifier(h.f, "$skip")
   usedParameterIndexes := parameters.flatMap (p, i) ->
     if usesIdentifier(h.f, p)
       [i]
@@ -455,16 +456,25 @@ ${valueDecl}  const $$m = `
   finalAnno := if types
     if retType then `: MaybeResult<${retType.trim()}>` else ": MaybeResult<typeof $$m>"
   else ""
-  skipCast := types ? " as any" : ""
   rValueCast := types ? " as any" : ""
-  body.push `;
-  const $$final${finalAnno} = ${conditionalExpression options,
-    `($$m${skipCast}) !== SKIP`
-    `(($$r${rValueCast}).value = $$m, $$r${rValueCast})`
-    "undefined"
-  };
-  ${exitHook("$$final")}
-  return $$final;`
+  body.push ";\n"
+  if handlerUsesSkip
+    skipCast := types ? " as any" : ""
+    body.push ```
+    \  const $$final${finalAnno} = ${conditionalExpression options,
+        `($$m${skipCast}) !== SKIP`
+        `(($$r${rValueCast}).value = $$m, $$r${rValueCast})`
+        "undefined"
+      };
+      ${exitHook("$$final")}
+      return $$final;
+    ```
+  else
+    body.push ```
+    \  ($$r${rValueCast}).value = $$m;
+      ${exitHook("$$r")}
+      return $$r${finalAnno && ` as unknown as ${finalAnno.replace(/^: /, "")}`};
+    ```
   return { helpers, body }
 
 compileRule := (options: CompilerOptions, name: string, rule: HeraAST) ->

--- a/source/machine.civet
+++ b/source/machine.civet
@@ -408,7 +408,7 @@ export function $TR<A extends unknown[], T>(
     // If A is an array (e.g. RegExpMatchArray, which extends string[]), then
     //   $0...$9 will be the type of the array's elements (e.g. string)
   ) => T
-): Parser<T> {
+): Parser<Exclude<T, typeof SKIP>> {
   return function (ctx, state) {
     const result = parser(ctx, state);
     if (!result) return
@@ -423,7 +423,7 @@ export function $TR<A extends unknown[], T>(
 
     //@ts-ignore
     result.value = mappedValue
-    return result as unknown as ParseResult<T>
+    return result as unknown as ParseResult<Exclude<T, typeof SKIP>>
   }
 }
 
@@ -434,7 +434,7 @@ type TupleOrArrayAsArgs<A extends unknown[]> =
 
 
 // Transform sequence
-export function $TS<A extends any[], B>(parser: Parser<A>, fn: ($skip: typeof SKIP, $loc: Loc, value: A, ...args: A) => B): Parser<B> {
+export function $TS<A extends any[], B>(parser: Parser<A>, fn: ($skip: typeof SKIP, $loc: Loc, value: A, ...args: A) => B): Parser<Exclude<B, typeof SKIP>> {
   return function (ctx, state) {
     const result = parser(ctx, state);
     if (!result) return
@@ -449,12 +449,12 @@ export function $TS<A extends any[], B>(parser: Parser<A>, fn: ($skip: typeof SK
 
     //@ts-ignore
     result.value = mappedValue
-    return result as unknown as ParseResult<B>
+    return result as unknown as ParseResult<Exclude<B, typeof SKIP>>
   }
 }
 
 // Transform value $0 and $1 are both singular value
-export function $TV<A, B>(parser: Parser<A>, fn: ($skip: typeof SKIP, $loc: Loc, $0: A, $1: A) => B): Parser<B> {
+export function $TV<A, B>(parser: Parser<A>, fn: ($skip: typeof SKIP, $loc: Loc, $0: A, $1: A) => B): Parser<Exclude<B, typeof SKIP>> {
   return function (ctx, state) {
     const result = parser(ctx, state);
     if (!result) return
@@ -469,7 +469,7 @@ export function $TV<A, B>(parser: Parser<A>, fn: ($skip: typeof SKIP, $loc: Loc,
 
     //@ts-ignore
     result.value = mappedValue
-    return result as unknown as ParseResult<B>
+    return result as unknown as ParseResult<Exclude<B, typeof SKIP>>
   }
 }
 
@@ -540,7 +540,7 @@ export function $EVENT_C<T extends Parser<any>[]>(ctx: ParserContext, state: Par
  * Sentinel returned from inlined rule handlers to signal "treat this rule as a
  * failed match" (reachable via the `$skip` parameter in hera grammars).
  */
-export const SKIP = {}
+export const SKIP: unique symbol = Symbol("SKIP")
 
 // End of machinery
 // Parser specific things below

--- a/test/main.civet
+++ b/test/main.civet
@@ -1011,10 +1011,10 @@ describe "Hera", ->
           return $skip
 
       V
-        "" -> true
+        "" -> "ok"
     """
 
-    assert parse ""
+    assert.equal parse(""), "ok"
 
   describe "named parameters", ->
     it "should provide named parameters for a sequence", ->
@@ -1243,6 +1243,14 @@ describe "Hera", ->
       """
       result := compile(parse(grammar), language: 'civet')
       assert.match result, /: ParseState/
+
+    it "should use Civet if expression for skip handlers", ->
+      grammar := """
+        Rule
+          "a" -> $skip
+      """
+      result := compile(parse(grammar), language: 'civet')
+      assert.match result, / = if \(\$\$m as any\) !== SKIP then /m
 
     it "should indent inline civet handlers by two spaces", ->
       grammar := """

--- a/test/main.civet
+++ b/test/main.civet
@@ -1045,7 +1045,7 @@ describe "Hera", ->
       """
       result := compile(parse(grammar), language: 'javascript')
       assert.match result, /\(function\(a\) \{/m
-      assert.match result, /\}\)\(\$\$value\[0\]\)/m
+      assert.match result, /\}\)\(\$\$r\.value\[0\]\)/m
       assert.doesNotMatch result, /var a = \$1/
 
     it "should not void named parameters", ->
@@ -1054,7 +1054,7 @@ describe "Hera", ->
           "a":a -> a
       """
       result := compile(parse(grammar), language: 'typescript')
-      assert.match result, /\(function\(a: typeof \$\$value\) \{/m
+      assert.match result, /\(function\(a: typeof \$\$r\.value\) \{/m
       assert.doesNotMatch result, /void[^;]*a;/
 
     it "should reject duplicate named parameters", ->
@@ -1319,10 +1319,10 @@ describe "Hera", ->
             return $1
       """
       result := compile(parse(grammar), language: 'javascript')
-      // Regex handlers call the IIFE with `$$value[i]` for each positional
-      // (cached off `$$r.value` once per call); the `as any[]` cast is TS-only
-      // so it must not leak into JS output.
-      assert.match result, /\$\$value\[1\]/
+      // Regex handlers emit single positional access directly from
+      // `$$r.value`; the `as any[]` cast is TS-only so it must not leak into
+      // JS output.
+      assert.match result, /\$\$r\.value\[1\]/
       assert.doesNotMatch result, /as any\[\]/
 
     it "should omit unused handler arguments and cached locals", ->
@@ -1349,14 +1349,14 @@ describe "Hera", ->
       assert.doesNotMatch result, /\(function\(\$loc/
       assert.doesNotMatch result, /\}\)\(\$\$r\.loc\)/
 
-    it "should cache parser value when value arguments are used", ->
+    it "should cache parser value when repeated value arguments are used", ->
       grammar := """
         Rule
           "a" ->
-            return $0
+            return [$0, $1]
       """
       result := compile(parse(grammar), language: 'typescript')
       assert.match result, /\(function\(\$0:/m
-      assert.match result, /\}\)\(\$\$value\)/m
       assert.match result, /\$\$value = \$\$r\.value/
-      assert.match result, /void \$0;/
+      assert.match result, /\$\$value = \$\$r\.value;[\s\S]*\}\)\(\$\$value, \$\$value\)/m
+      assert.match result, /void \$0, \$1;/

--- a/test/skip.test-d.ts
+++ b/test/skip.test-d.ts
@@ -1,0 +1,10 @@
+import { Rule } from "./skip.hera"
+
+const expectType = <T>(_: T): void => void 0
+type TypeEqual<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2)
+    ? true : false
+
+type RuleValue = NonNullable<ReturnType<typeof Rule>>["value"]
+
+expectType<TypeEqual<RuleValue, string>>(true)


### PR DESCRIPTION
This PR aims to reduce the size of generated code and generally clean things up. It should also improve types w.r.t. `$skip`. For this, `SKIP` became a symbol.

**Motivation:** compare the size of Civet's `main.js` and its self compilation time (`build/perf-compare.sh`)

| Version | Size (main.js) | Compile time |
|---|---:|---:|
| **0.9.0** (before rewrite) | 0.868 MB | 3.9194 s |
| **0.9.1** (after rewrite) | 1.778 MB | 4.2088 s |
| **0.9.4** (after my last optimizations) | 1.669 MB | 4.1099 s |
| **0.9.5 = main** (after tokenizer removal) | 1.418 MB | 3.8807 s |
| **PR** | 1.269 MB | 3.7785 s |

We're slowly getting back to our original size...

Here's a list of optimizations I did, one commit each:

- Use `||` chains for rule options.

  ```ts
  // before
  let $$final = A($$ctx, $$state);
  if (!$$final) $$final = B($$ctx, $$state);
  if (!$$final) $$final = C($$ctx, $$state);

  // after
  const $$final = A($$ctx, $$state) || B($$ctx, $$state) || C($$ctx, $$state);
  ```

- Emit grammar objects with shorthand properties.

  ```ts
  // before
  const grammar = {
    Rule: Rule,
    A: A,
    B: B
  };

  // after
  const grammar = {
    Rule,
    A,
    B
  };
  ```

- Use a conditional expression for `$skip` finalization.

  ```ts
  // before
  let $$final: MaybeResult<Exclude<typeof $$m, typeof SKIP>>;
  if (($$m as any) !== SKIP) {
    ($$r as any).value = $$m;
    $$final = $$r as any;
  }
  $$ctx.exit?.("Rule", $$state, $$final, $$eventData);
  return $$final;

  // after
  const $$final: MaybeResult<Exclude<typeof $$m, typeof SKIP>> = ($$m as any) !== SKIP
    ? (($$r as any).value = $$m, $$r as any)
    : undefined;
  $$ctx.exit?.("Rule", $$state, $$final, $$eventData);
  return $$final;
  ```

- Skip the `$skip` check when the handler does not reference `$skip`. Introduce new ternary helper which uses `if...then...else...` in Civet output.

  ```ts
  // before
  const $$m = (function() {
    return "ok";
  })();
  const $$final = ($$m as any) !== SKIP
    ? (($$r as any).value = $$m, $$r as any)
    : undefined;
  return $$final;

  // after
  const $$m = (function() {
    return "ok";
  })();
  ($$r as any).value = $$m;
  return $$r as unknown as MaybeResult<Exclude<typeof $$m, typeof SKIP>>;
  ```

- Exclude `$skip` from generated TypeScript result types.

  ```ts
  // before
  return $$final as MaybeResult<typeof $$m>;

  // after
  return $$final as MaybeResult<Exclude<typeof $$m, typeof SKIP>>;
  ```

- Use optional chaining for event hooks.

  ```ts
  // before
  const $$entered = $$ctx.enter && $$ctx.enter("Rule", $$state);
  const $$eventData = $$entered && $$entered.data;
  if ($$ctx.exit) $$ctx.exit("Rule", $$state, $$final, $$eventData);

  // after
  const $$entered = $$ctx.enter?.("Rule", $$state);
  const $$eventData = $$entered?.data;
  $$ctx.exit?.("Rule", $$state, $$final, $$eventData);
  ```

- Avoid caching `$$r.value` when it is only used once.

  ```ts
  // before
  const $$value = $$r.value;
  const $$m = (function(a: typeof $$value) {
    return a;
  })($$value);

  // after
  const $$m = (function(a: typeof $$r.value) {
    return a;
  })($$r.value);
  ```

- Remove redundant generated TypeScript annotations on event temporaries.

  ```ts
  // before
  const $$entered: { cache?: unknown, data?: unknown } | undefined = $$ctx.enter?.("Rule", $$state);
  const $$eventData: unknown = $$entered?.data;

  // after
  const $$entered = $$ctx.enter?.("Rule", $$state);
  const $$eventData = $$entered?.data;
  ```


I ran Civet's `test` and `test:self` with this PR and everything works fine.