### PR TITLE
Use `??=` for rule-options dispatch (fix tsc stack overflow on parser.hera)

### DIFF
--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -527,10 +527,10 @@ compileRule := (options: CompilerOptions, name: string, rule: HeraAST) ->
   // ruleReturnType).  Otherwise let TS infer the union from the body.
   retAnno := if types and retType then `: MaybeResult<${retType.trim()}>` else ""
 
-  // Declare $$final at a union type so the `||` chain normalizes to
-  // `MaybeResult<X | Y>` instead of `ParseResult<X> | MaybeResult<Y>`.
-  // With an explicit ::Type, use it directly.  Without one, build
-  // `MaybeResult<Unwrap<ReturnType<typeof X$0>> | ...>` from each
+  // Declare $$final at a wide union type so successive `??=` reassignments
+  // (each returning unrelated literal types) don't collide on a let binding's
+  // narrow initial type.  With an explicit ::Type, use it directly.  Without
+  // one, build `MaybeResult<Unwrap<ReturnType<typeof X$0>> | ...>` from each
   // alternative — Unwrap strips the ParseResult wrapper so the union is on
   // the inner value types, which lets TS keep `Parser<T>` inference clean
   // when the rule is used inside `$S(...)` etc.
@@ -541,11 +541,17 @@ compileRule := (options: CompilerOptions, name: string, rule: HeraAST) ->
       altUnion := args.map((_, i) -> `Unwrap<ReturnType<typeof ${name}$${i}>>`).join(" | ")
       `: MaybeResult<${altUnion}>`
   else ""
-  tryBlock := [
-    `  const $$final${finalWideDecl} = `
-    args.map((_, i) -> `${name}$${i}($$ctx, $$state)`).join("\n    || ")
-    `;\n`
-  ]
+  // Statement-form `??=` rather than `const = X || Y || …`: a chained-`||`
+  // const initializer puts every alternative call into one contextually-typed
+  // expression that TS resolves all-at-once, which (combined with rule bodies
+  // that materialize `typeof $$r`) blows TS's stack on heavily mutually-
+  // recursive grammars like Civet's parser.hera.  Per-statement `??=` lets
+  // each call's return type be resolved independently.
+  tryBlock := args.map (_, i) ->
+    if i is 0
+      `  let $$final${finalWideDecl} = ${name}$${i}($$ctx, $$state);\n`
+    else
+      `  $$final ??= ${name}$${i}($$ctx, $$state);\n`
 
   [
     ...allHelpers.flatMap((h) -> [h, "\n\n"])

--- a/test/civet-typecheck-overflow.civet
+++ b/test/civet-typecheck-overflow.civet
@@ -1,0 +1,82 @@
+import assert from 'assert'
+import { mkdtempSync, writeFileSync, rmSync, copyFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { execFileSync } from 'child_process'
+
+import { compile, parse } from '../source/main.civet'
+import { compile as civetCompile } from '@danielx/civet'
+
+// Civet's parser.hera exposes a TS-side regression in the compiled parser:
+// the `||`-chain dispatcher's contextually-typed expression (combined with
+// the const-ternary-with-comma rule body for `$skip` handlers) blows TS's
+// stack on a deep mutually-recursive rule graph.  The overflow lands in a
+// few different TS internals (`isConstContext`, `resolveEntityName`,
+// `instantiateTypeWithSingleGenericCallSignature`, …) depending on which
+// frame happens to run out of stack first; the underlying recursion loop
+// is consistent.  Bug repros at ~N=175 rules with the broken compiler;
+// we test at N=200 so a small TS-version drift can't make this flaky.
+buildRecursiveGrammar := (n: number): string ->
+  rules := ['Leaf\n  /[a-z]+/ -> $1\n']
+  for i of [0...n]
+    a := (i + 1) % n
+    b := (i + 2) % n
+    rules.push `R${i}
+  R${a}:p R${b}:q ->
+    if (!p) return $skip
+    return [p, q]
+  R${b}
+  Leaf -> $1
+`
+  rules.join("\n")
+
+describe "Regression: tsc stack overflow on heavily mutually-recursive grammars (PR #86)", ->
+  it "compiles + typechecks a 200-rule recursive grammar without exceeding TS's call stack", ->
+    @timeout 30000
+
+    grammar := buildRecursiveGrammar(200)
+
+    // Stage 1: Hera grammar → Civet code (matches Civet's plugin path,
+    // which calls `hera.compile(source, { module: true, sourceMap: true })`
+    // — no `types`, no `language`).
+    heraOut := compile(parse(grammar), { module: true })
+
+    // Stage 2: Civet code → TS.
+    civetOut := civetCompile(heraOut, { filename: 'fixture.hera', js: false, sync: true }) as string
+
+    // Stage 3: tsc on the result.  Spawn rather than embed so a stack
+    // overflow stays contained in the child process.
+    dir := mkdtempSync(join(tmpdir(), 'hera-overflow-'))
+    try
+      copyFileSync('dist/machine.js', join(dir, 'machine.js'))
+      copyFileSync('dist/machine.d.ts', join(dir, 'machine.d.ts'))
+      writeFileSync(join(dir, 'parser.ts'), civetOut)
+      tsconfig := """
+        {
+          "compilerOptions": {
+            "target": "ES2022",
+            "module": "ESNext",
+            "moduleResolution": "Bundler",
+            "strict": false,
+            "noEmit": true,
+            "skipLibCheck": true,
+            "esModuleInterop": true,
+            "noImplicitAny": false
+          },
+          "include": ["parser.ts", "machine.d.ts"]
+        }
+        """
+      writeFileSync(join(dir, 'tsconfig.json'), tsconfig)
+
+      tsc := join(process.cwd(), 'node_modules', '.bin', 'tsc')
+      let out: string = ""
+      try
+        out = execFileSync(tsc, ['-p', 'tsconfig.json'], { cwd: dir, encoding: 'utf8' })
+      catch err
+        e := err as { stdout?: string, stderr?: string, message?: string }
+        out = (e.stdout ?? "") + (e.stderr ?? "") + (e.message ?? "")
+
+      assert.doesNotMatch out, /Maximum call stack size exceeded/,
+        "tsc stack-overflowed on a 200-rule recursive grammar — the dispatcher's `||` chain (or another aggregating-expression form) is back."
+    finally
+      rmSync dir, { recursive: true, force: true }


### PR DESCRIPTION
## Summary
- 0.9.6's `const $$final = X$0() || X$1() || …` rule-options dispatcher introduced a regression: `tsc` stack-overflows when typechecking heavily mutually-recursive grammars, including [Civet's `parser.hera`](https://github.com/DanielXMoore/Civet/blob/main/source/parser.hera) (~9.5k lines, ~290 multi-alternative rules).
- Switched the dispatcher to a per-statement `??=` reassignment chain.  Same runtime semantics, same control flow, but each alternative call is typechecked independently instead of being unified into one contextually-typed `||` expression.
- Kept the variable name `$$final` and the type-narrowing rationale (the wide `MaybeResult<X | Y | …>` annotation, computed via `Unwrap<ReturnType<typeof X$i>>`) intact.

## Root cause
With the `||`-chain const initializer, TS resolves the entire chain's contextual type in one pass.  Combined with rule bodies that materialize `typeof $$r` (the const-ternary-with-comma form for `$skip`-using handlers), the recursion through Civet's mutually-recursive rule graph blows the stack.  Per-statement `??=` short-circuits this: each rule call's return type is resolved on its own line.

The fix is a single `tryBlock :=` swap in `compileRule`.  See the comment block in the diff for the analysis.

## Test plan
- [x] `pnpm test` — 146 unit tests pass (incl. the runtime `$skip` test that actually executes a generated parser).
- [x] `pnpm test:typed-parser-samples` — strict-mode `tsc` on the bundled sample grammars still passes.
- [x] Civet's `parser.hera` end-to-end (`hera.compile` → `civet.compile` → `tsc -p tsconfig.json`) completes without `Maximum call stack size exceeded`.  Repro is wired up at `/tmp/hera-civet-repro/` (a small `build.mjs` harness + stub modules + `tsconfig.json`); happy to upstream it under `perf/` or as a regression test if useful.

## Size impact (Civet's parser.hera, post-Civet TS output)
| | bytes | vs 0.9.5 | vs 0.9.6 (broken) |
|---|---|---|---|
| 0.9.5 | 1,098,598 | — | +143 KB |
| 0.9.6 (`main`, broken) | 955,426 | −143 KB | — |
| **this PR** | **960,242** | **−138 KB (−12.6%)** | +5 KB (+0.5%) |

Almost all of 0.9.6's size win is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)