### PR TITLE
Type `$skip` as `never` to drop `Exclude<T, typeof SKIP>` wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to `@danielx/hera` will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+- `$skip` is typed as `never` in handler signatures, eliminating the
+  `Exclude<T, typeof SKIP>` wrappers on `$TR`/`$TS`/`$TV` return types and
+  on the rule function's `$$final` annotation.  Returning `$skip` still
+  marks the rule as a failed match at runtime, but no longer widens the
+  handler's inferred return type — so the cleanup wrappers become
+  unnecessary.
+
 ## [0.9.6] - 2026-04-30
 
 ### Performance

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -458,9 +458,9 @@ ${valueDecl}  const $$m = `
   // assignment from $$r is just to bypass the structural mismatch (TS still
   // believes $$r.value has its old shape pre-mutation).
   finalType := if types
-    `MaybeResult<Exclude<${
+    `MaybeResult<${
       if retType then retType.trim() else "typeof $$m"
-    }, typeof SKIP>>`
+    }>`
   else ""
   rValueCast := types ? " as any" : ""
   body.push ";\n"
@@ -655,7 +655,7 @@ export function compile(rules: HeraRules, maybeOptions?: CompilerOptions): strin
     head
     `\n\nconst grammar = ${compileRulesObject(ruleNames)};\n\n`
     `\n\nconst grammarDefaultRule = ${JSON.stringify(ruleNames[0])};\n\n`
-    `const $skip${types ? ": (typeof SKIP)" : ""} = SKIP; void $skip;\n\n`
+    `const $skip${types ? ": never" : ""} = SKIP${types ? " as never" : ""}; void $skip;\n\n`
     strDefSource
     "\n\n"
     reDefSource

--- a/source/machine.civet
+++ b/source/machine.civet
@@ -400,7 +400,7 @@ export function $T<A, B>(parser: Parser<A>, fn: (value: A) => B): Parser<B> {
 export function $TR<A extends unknown[], T>(
   parser: Parser<A>,
   fn: (
-    $skip: typeof SKIP,
+    $skip: never,
     $loc: Loc,
     ...args: TupleOrArrayAsArgs<A> // This properly assigns the types of the arguments.
     // If A is a tuple, e.g. ['a'|'b', 'foo'|'bar'] then $0 will be 'a'|'b' and
@@ -408,22 +408,22 @@ export function $TR<A extends unknown[], T>(
     // If A is an array (e.g. RegExpMatchArray, which extends string[]), then
     //   $0...$9 will be the type of the array's elements (e.g. string)
   ) => T
-): Parser<Exclude<T, typeof SKIP>> {
+): Parser<T> {
   return function (ctx, state) {
     const result = parser(ctx, state);
     if (!result) return
 
     const { loc, value } = result
-    const mappedValue = fn(SKIP, loc, ...(value as TupleOrArrayAsArgs<A>))
+    const mappedValue = fn(SKIP as never, loc, ...(value as TupleOrArrayAsArgs<A>))
 
-    if (mappedValue === SKIP) {
+    if (mappedValue as unknown === SKIP) {
       // TODO track fail?
       return
     }
 
     //@ts-ignore
     result.value = mappedValue
-    return result as unknown as ParseResult<Exclude<T, typeof SKIP>>
+    return result as unknown as ParseResult<T>
   }
 }
 
@@ -434,42 +434,42 @@ type TupleOrArrayAsArgs<A extends unknown[]> =
 
 
 // Transform sequence
-export function $TS<A extends any[], B>(parser: Parser<A>, fn: ($skip: typeof SKIP, $loc: Loc, value: A, ...args: A) => B): Parser<Exclude<B, typeof SKIP>> {
+export function $TS<A extends any[], B>(parser: Parser<A>, fn: ($skip: never, $loc: Loc, value: A, ...args: A) => B): Parser<B> {
   return function (ctx, state) {
     const result = parser(ctx, state);
     if (!result) return
 
     const { loc, value } = result
-    const mappedValue = fn(SKIP, loc, value, ...value)
+    const mappedValue = fn(SKIP as never, loc, value, ...value)
 
-    if (mappedValue === SKIP) {
+    if (mappedValue as unknown === SKIP) {
       // TODO track fail?
       return
     }
 
     //@ts-ignore
     result.value = mappedValue
-    return result as unknown as ParseResult<Exclude<B, typeof SKIP>>
+    return result as unknown as ParseResult<B>
   }
 }
 
 // Transform value $0 and $1 are both singular value
-export function $TV<A, B>(parser: Parser<A>, fn: ($skip: typeof SKIP, $loc: Loc, $0: A, $1: A) => B): Parser<Exclude<B, typeof SKIP>> {
+export function $TV<A, B>(parser: Parser<A>, fn: ($skip: never, $loc: Loc, $0: A, $1: A) => B): Parser<B> {
   return function (ctx, state) {
     const result = parser(ctx, state);
     if (!result) return
 
     const { loc, value } = result
-    const mappedValue = fn(SKIP, loc, value, value)
+    const mappedValue = fn(SKIP as never, loc, value, value)
 
-    if (mappedValue === SKIP) {
+    if (mappedValue as unknown === SKIP) {
       // TODO track fail?
       return
     }
 
     //@ts-ignore
     result.value = mappedValue
-    return result as unknown as ParseResult<Exclude<B, typeof SKIP>>
+    return result as unknown as ParseResult<B>
   }
 }
 


### PR DESCRIPTION
## Summary
- `$skip` is now typed as `never` in handler signatures (`$TR`/`$TS`/`$TV` in `source/machine.civet`, and the generated prelude in `source/compiler.civet`).
- Because `never` doesn't widen the handler's inferred return type, the `Exclude<T, typeof SKIP>` wrappers on those parsers' return types and on the rule function's `$$final` annotation are no longer load-bearing and have been removed.
- Costs: one extra `as never` cast in the generated `$skip` declaration, and `SKIP as never` at the three internal call sites that pass it to `fn(...)`. The runtime `=== SKIP` checks now read `mappedValue as unknown === SKIP` to satisfy TS now that `mappedValue` no longer overlaps `typeof SKIP`.

## Why
Returning `$skip` is the only documented use — the SKIP sentinel never surfaces in user values, and the runtime checks for it independently inside the helper. Typing the parameter as `never` reflects that: it lets `return $skip` flow through any handler without polluting the inferred type, so the `Exclude<...>` cleanup wrappers become unnecessary.

## Caveat
Any user handler that compared `=== $skip` (rather than returning it) would become a TS no-overlap error. The documented surface is `return $skip`, and there's no semantic reason to compare against it since SKIP can never reach user values — but worth flagging.

## Test plan
- [x] `pnpm test` — 146 passing, 100% coverage retained
- [x] `pnpm test:typed-parser-samples` — `tsc` against generated TS parsers passes
- [x] `pnpm test:esbuild-plugin` — passes
- [x] `pnpm test:loaders` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)