### PR TITLE
Type annotation of rule names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to `@danielx/hera` will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Grammar: `RuleName ::Type` sets a default return type for every untyped
+  choice in that rule.  A `::Type` on an individual choice still overrides
+  the rule-level default (#91).
+
 ## [0.9.7] - 2026-05-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ Both `&` and `!` predicates returns `true`, so that matching vs. not can be dist
 can be specified explicitly using `::type` after the choice and before the
 handler (if any — otherwise, it returns the default value).
 This return type gets emitted when generating TypeScript or Civet output.
+You can also write `RuleName ::type` on a rule header to use that type as the
+default for every choice in the rule.
 
 **Handler**: A mapping from the matched choice to a language primitive.
 Handlers are attached to rule choices by adding `->` after the choice.

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -152,7 +152,7 @@ ruleReturnType := (rule: HeraAST): string | undefined ->
       return arg[2].t if arg.length is 3 and arg[2]
       return undefined
     if subTypes.every((t) -> t?)
-      return subTypes.map((t) -> t!.trim()).join(" | ")
+      return [...new Set(subTypes.map((t) -> t!.trim()))].join(" | ")
     return undefined
   if rule.length is 3 and rule[2]
     return rule[2].t

--- a/source/hera.hera
+++ b/source/hera.hera
@@ -1,5 +1,6 @@
 ```
 import type {
+  HeraAST,
   SequenceNode,
   NameNode,
   Handler,
@@ -22,13 +23,25 @@ CodeBlock
   TripleBacktick CodeBody TripleBacktick -> $2
 
 Rule
-  Name EOS RuleBody -> [$1, $3]
+  Name RuleBody -> [$1, $2]
+
+RuleTypeAnnotation
+  Space* TypeAnnotation -> $2
 
 RuleBody
-  ( Indent Choice )+ ->
-    var r = $1.map((a) => a[1])
+  RuleTypeAnnotation?:t EOS ( Indent Choice )+:choices :: HeraAST ->
+    var r: HeraAST[] = choices.map((a) => a[1] as HeraAST)
+    if (t) r = r.map((a): HeraAST => {
+      if (typeof a === "string") return ["S", [a], { t }] as unknown as HeraAST
+      const handler = a[2]
+      if (handler) {
+        if ("t" in handler) return a
+        return [a[0], a[1], { ...handler, t }] as unknown as HeraAST
+      }
+      return [a[0], a[1], { t }] as unknown as HeraAST
+    })
     if (r.length === 1) return r[0];
-    return ["/", r]
+    return ["/", r] as HeraAST
 
 Choice
   Sequence Handling ->

--- a/source/rules.json
+++ b/source/rules.json
@@ -2,10 +2,10 @@
   "code": [
     {
       "type": "CodeBlock",
-      "token": "\nimport type {\n  SequenceNode,\n  NameNode,\n  Handler,\n  CodeBlockNode,\n} from './hera-types'\n",
+      "token": "\nimport type {\n  HeraAST,\n  SequenceNode,\n  NameNode,\n  Handler,\n  CodeBlockNode,\n} from './hera-types'\n",
       "$loc": {
         "pos": 3,
-        "length": 93
+        "length": 104
       }
     }
   ],
@@ -16,7 +16,7 @@
       {
         "f": "    const code = $1.filter(a => typeof a === \"object\" && a !== null && \"type\" in a && a.type === \"CodeBlock\")\n    const rules = Object.fromEntries($1.filter(a => Array.isArray(a)))\n    rules[Symbol.for(\"code\")] = code\n    return rules",
         "$loc": {
-          "pos": 125,
+          "pos": 136,
           "length": 236
         }
       }
@@ -36,7 +36,7 @@
           {
             "f": "$2",
             "$loc": {
-              "pos": 391,
+              "pos": 402,
               "length": 3
             },
             "inline": true
@@ -54,7 +54,7 @@
           {
             "f": "$2",
             "$loc": {
-              "pos": 409,
+              "pos": 420,
               "length": 4
             },
             "inline": true
@@ -72,7 +72,7 @@
       {
         "f": "$2",
         "$loc": {
-          "pos": 467,
+          "pos": 478,
           "length": 4
         },
         "inline": true
@@ -82,33 +82,71 @@
       "S",
       [
         "Name",
-        "EOS",
         "RuleBody"
       ],
       {
-        "f": "[$1, $3]",
+        "f": "[$1, $2]",
         "$loc": {
-          "pos": 499,
+          "pos": 506,
           "length": 10
         },
         "inline": true
       }
     ],
-    "RuleBody": [
-      "+",
+    "RuleTypeAnnotation": [
+      "S",
       [
-        "S",
         [
-          "Indent",
-          "Choice"
+          "*",
+          "Space"
+        ],
+        "TypeAnnotation"
+      ],
+      {
+        "f": "$2",
+        "$loc": {
+          "pos": 562,
+          "length": 4
+        },
+        "inline": true
+      }
+    ],
+    "RuleBody": [
+      "S",
+      [
+        [
+          {
+            "name": "t"
+          },
+          [
+            "?",
+            "RuleTypeAnnotation"
+          ]
+        ],
+        "EOS",
+        [
+          {
+            "name": "choices"
+          },
+          [
+            "+",
+            [
+              "S",
+              [
+                "Indent",
+                "Choice"
+              ]
+            ]
+          ]
         ]
       ],
       {
-        "f": "    var r = $1.map((a) => a[1])\n    if (r.length === 1) return r[0];\n    return [\"/\", r]",
+        "f": "    var r: HeraAST[] = choices.map((a) => a[1] as HeraAST)\n    if (t) r = r.map((a): HeraAST => {\n      if (typeof a === \"string\") return [\"S\", [a], { t }] as unknown as HeraAST\n      const handler = a[2]\n      if (handler) {\n        if (\"t\" in handler) return a\n        return [a[0], a[1], { ...handler, t }] as unknown as HeraAST\n      }\n      return [a[0], a[1], { t }] as unknown as HeraAST\n    })\n    if (r.length === 1) return r[0];\n    return [\"/\", r] as HeraAST",
         "$loc": {
-          "pos": 542,
-          "length": 90
-        }
+          "pos": 644,
+          "length": 471
+        },
+        "t": " HeraAST "
       }
     ],
     "Choice": [
@@ -120,7 +158,7 @@
       {
         "f": "    if ($2 !== undefined) {\n      if (!$1.push)\n        $1 = [\"S\", [$1], $2]\n      else\n        $1.push($2)\n    }\n    return $1",
         "$loc": {
-          "pos": 662,
+          "pos": 1145,
           "length": 129
         }
       }
@@ -140,7 +178,7 @@
           {
             "f": "    $2.unshift($1)\n    return [\"S\", $2]",
             "$loc": {
-              "pos": 852,
+              "pos": 1335,
               "length": 40
             },
             "t": " SequenceNode "
@@ -158,7 +196,7 @@
           {
             "f": "    $2.unshift($1)\n    return [\"/\", $2]",
             "$loc": {
-              "pos": 942,
+              "pos": 1425,
               "length": 40
             },
             "t": " SequenceNode "
@@ -176,7 +214,7 @@
       {
         "f": "$2",
         "$loc": {
-          "pos": 1037,
+          "pos": 1520,
           "length": 4
         },
         "inline": true
@@ -196,7 +234,7 @@
       {
         "f": "$4",
         "$loc": {
-          "pos": 1090,
+          "pos": 1573,
           "length": 4
         },
         "inline": true
@@ -214,7 +252,7 @@
       {
         "f": "$2",
         "$loc": {
-          "pos": 1122,
+          "pos": 1605,
           "length": 4
         },
         "inline": true
@@ -236,7 +274,7 @@
       {
         "f": "    var result = null\n    if ($1) result = [$1, $2]\n    else result = $2\n    if ($3)\n      return [{name: $3}, result] as NameNode\n    return result as SequenceNode",
         "$loc": {
-          "pos": 1207,
+          "pos": 1690,
           "length": 166
         },
         "t": " SequenceNode | NameNode "
@@ -258,7 +296,7 @@
       {
         "f": "    if ($2) return [$2, $1]\n    else return $1",
         "$loc": {
-          "pos": 1433,
+          "pos": 1916,
           "length": 48
         }
       }
@@ -282,7 +320,7 @@
           {
             "f": "$2",
             "$loc": {
-              "pos": 1577,
+              "pos": 2060,
               "length": 4
             },
             "inline": true
@@ -308,7 +346,7 @@
           {
             "f": "    return undefined",
             "$loc": {
-              "pos": 1640,
+              "pos": 2123,
               "length": 21
             }
           }
@@ -340,7 +378,7 @@
           {
             "f": "    if (t) handler = { ...handler, t }\n    return handler as Handler",
             "$loc": {
-              "pos": 1724,
+              "pos": 2207,
               "length": 69
             }
           }
@@ -363,7 +401,7 @@
           {
             "f": "    return { t } as Handler",
             "$loc": {
-              "pos": 1965,
+              "pos": 2448,
               "length": 29
             }
           }
@@ -386,7 +424,7 @@
           {
             "f": "$2",
             "$loc": {
-              "pos": 2200,
+              "pos": 2683,
               "length": 49
             },
             "inline": true
@@ -400,7 +438,7 @@
           {
             "f": "    return {\n      f: $1.trimEnd(),\n      $loc,\n      inline: true,\n    }",
             "$loc": {
-              "pos": 2290,
+              "pos": 2773,
               "length": 75
             },
             "t": " Handler "
@@ -414,7 +452,7 @@
       {
         "f": "    return {\n      f: $1.join(\"\").trimEnd(),\n      $loc,\n    }",
         "$loc": {
-          "pos": 2428,
+          "pos": 2911,
           "length": 64
         },
         "t": " Handler "
@@ -467,7 +505,7 @@
       {
         "f": "    return $1 + $2.join(\"\") + ($3 ?? \"\")",
         "$loc": {
-          "pos": 2975,
+          "pos": 3458,
           "length": 42
         },
         "t": " string "
@@ -509,7 +547,7 @@
       {
         "f": "$2",
         "$loc": {
-          "pos": 3281,
+          "pos": 3764,
           "length": 4
         },
         "inline": true
@@ -546,7 +584,7 @@
       {
         "f": "[\"L\", $1]",
         "$loc": {
-          "pos": 3401,
+          "pos": 3884,
           "length": 11
         },
         "inline": true
@@ -581,7 +619,7 @@
           {
             "f": "[\"R\", $3]",
             "$loc": {
-              "pos": 3464,
+              "pos": 3947,
               "length": 10
             },
             "inline": true
@@ -593,7 +631,7 @@
           {
             "f": "[\"R\", $1]",
             "$loc": {
-              "pos": 3505,
+              "pos": 3988,
               "length": 10
             },
             "inline": true
@@ -605,7 +643,7 @@
           {
             "f": "[\"R\", $1]",
             "$loc": {
-              "pos": 3524,
+              "pos": 4007,
               "length": 11
             },
             "inline": true
@@ -749,7 +787,7 @@
       {
         "f": "$2",
         "$loc": {
-          "pos": 4695,
+          "pos": 5178,
           "length": 4
         },
         "inline": true
@@ -764,7 +802,7 @@
       {
         "f": "    return {\n      type: \"CodeBlock\",\n      token: $0,\n      $loc,\n    }",
         "$loc": {
-          "pos": 4755,
+          "pos": 5238,
           "length": 73
         },
         "t": " CodeBlockNode "

--- a/source/util.civet
+++ b/source/util.civet
@@ -34,6 +34,10 @@ handler to source
 hToS := (h: Handler | undefined): string ->
   return "" unless h?
 
+  // Type annotation without handler, e.g. `Rule ::Type`
+  if "t" in h and !("f" in h)
+    return ` :: ${h.t.trim()}`
+
   unless h is like { f } and h.f <? "string"
     throw new Error "Unknown handler format"
 

--- a/test/main.civet
+++ b/test/main.civet
@@ -191,6 +191,39 @@ describe "Hera", ->
     assert.match code, /function Rule\(\$\$ctx: ParserContext, \$\$state: ParseState\) \{/
     assert.doesNotMatch code, /function Rule\(\$\$ctx: ParserContext, \$\$state: ParseState\): MaybeResult/
 
+  it "should apply a rule-level type annotation to untyped alternatives", ->
+    grammar := """
+      Rule ::Default
+        "a" -> "a"
+        "b" ::Specific -> "b"
+        Inner
+        "d"
+
+      Inner
+        "c" -> "c"
+    """
+    rules := parse grammar
+
+    assert.equal rules.Rule[1][0][2].t.trim(), "Default"
+    assert.equal rules.Rule[1][1][2].t.trim(), "Specific"
+    assert.equal rules.Rule[1][2][2].t.trim(), "Default"
+    assert.equal rules.Rule[1][3][2].t.trim(), "Default"
+
+    parser := generate grammar
+    assert.equal parser.parse("a"), "a"
+    assert.equal parser.parse("b"), "b"
+    assert.equal parser.parse("c"), "c"
+    assert.equal parser.parse("d"), "d"
+
+    code := compile grammar, types: true
+    assert.match code, /function Rule\(\$\$ctx: ParserContext, \$\$state: ParseState\): MaybeResult<Default \| Specific>/
+
+    singleRules := parse """
+      Single ::Only
+        "s"
+    """
+    assert.equal singleRules.Single[2].t.trim(), "Only"
+
   it "should compile multi-line inline handler bodies", ->
     // Regression: an inline handler body that spans multiple lines
     // (`-> { ... }` with the object contents below) must emit code that's

--- a/test/util.civet
+++ b/test/util.civet
@@ -120,6 +120,16 @@ describe "util", ->
 
     assert.equal decompile(rules), grammar
 
+  it "should decompile type annotations without handlers", ->
+    grammar := """
+      Rule
+        N:x :: number
+
+    """
+    rules := parse grammar
+
+    assert.equal decompile(rules), grammar
+
   it "should throw an error when decompiling an unknown format", ->
     rules := parse """
       Rule


### PR DESCRIPTION
- Add `RuleName ::Type` syntax to set a default return type for every untyped choice in a rule
- Preserve alternative-level overrides, so `Choice ::OtherType` still takes precedence over the rule default
- Along the way, noticed and fixed decompilation for type annotations without handlers, such as `N:x :: number`
- (Note: decompilation is not going to be able to distinguish between type annotation at the rule name and choice level. Hope that's OK)

Fixes #91
