### PR TITLE
Types for long (>9) choices and sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `@danielx/hera` will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Type declarations for `$C` and `$S` now support generated parsers with more
+  than 9 choice alternatives or sequence items.
+
 ## [0.9.8] - 2026-05-26
 
 ### Added

--- a/source/machine.civet
+++ b/source/machine.civet
@@ -169,6 +169,7 @@ export function $C<A, B, C, D, E, F>(a: Parser<A>, b: Parser<B>, c: Parser<C>, d
 export function $C<A, B, C, D, E, F, H>(a: Parser<A>, b: Parser<B>, c: Parser<C>, d: Parser<D>, e: Parser<E>, f: Parser<F>, h: Parser<H>): Parser<A | B | C | D | E | F | H>
 export function $C<A, B, C, D, E, F, H, I>(a: Parser<A>, b: Parser<B>, c: Parser<C>, d: Parser<D>, e: Parser<E>, f: Parser<F>, h: Parser<H>, i: Parser<I>): Parser<A | B | C | D | E | F | H | I>
 export function $C<A, B, C, D, E, F, H, I, J>(a: Parser<A>, b: Parser<B>, c: Parser<C>, d: Parser<D>, e: Parser<E>, f: Parser<F>, h: Parser<H>, i: Parser<I>, j: Parser<J>): Parser<A | B | C | D | E | F | H | I | J>
+export function $C<T extends any[]>(...terms: { [I in keyof T]: Parser<T[I]> }): Parser<T[number]>
 
 export function $C<T extends any[]>(...terms: { [I in keyof T]: Parser<T[I]> }): Parser<T[number]> {
   return (ctx, state): MaybeResult<T[number]> => {
@@ -201,6 +202,7 @@ export function $S<A, B, C, D, E, F, G>(a: Parser<A>, b: Parser<B>, c: Parser<C>
 export function $S<A, B, C, D, E, F, G, H>(a: Parser<A>, b: Parser<B>, c: Parser<C>, d: Parser<D>, e: Parser<E>, f: Parser<F>, g: Parser<G>, h: Parser<H>): Parser<[A, B, C, D, E, F, G, H]>
 export function $S<A, B, C, D, E, F, G, H, I>(a: Parser<A>, b: Parser<B>, c: Parser<C>, d: Parser<D>, e: Parser<E>, f: Parser<F>, g: Parser<G>, h: Parser<H>, i: Parser<I>): Parser<[A, B, C, D, E, F, G, H, I]>
 export function $S<A, B, C, D, E, F, G, H, I, J>(a: Parser<A>, b: Parser<B>, c: Parser<C>, d: Parser<D>, e: Parser<E>, f: Parser<F>, g: Parser<G>, h: Parser<H>, i: Parser<I>, j: Parser<J>): Parser<[A, B, C, D, E, F, G, H, I, J]>
+export function $S<T extends any[]>(...terms: { [I in keyof T]: Parser<T[I]> }): Parser<T>
 
 export function $S<T extends any[]>(...terms: { [I in keyof T]: Parser<T[I]> }): Parser<T> {
   return (ctx, state): MaybeResult<T> => {

--- a/source/machine.civet
+++ b/source/machine.civet
@@ -158,19 +158,6 @@ export function $R<T = RegExpMatchArray>(regExp: RegExp): Parser<T> {
  * Proioritized choice
  * roughly a(...) || b(...) in JS
  */
-
-export function $C(): (ctx: ParserContext, state: ParseState) => undefined
-export function $C<A>(a: Parser<A>): Parser<A>
-export function $C<A, B>(a: Parser<A>, b: Parser<B>): Parser<A | B>
-export function $C<A, B, C>(a: Parser<A>, b: Parser<B>, c: Parser<C>): Parser<A | B | C>
-export function $C<A, B, C, D>(a: Parser<A>, b: Parser<B>, c: Parser<C>, d: Parser<D>): Parser<A | B | C | D>
-export function $C<A, B, C, D, E>(a: Parser<A>, b: Parser<B>, c: Parser<C>, d: Parser<D>, e: Parser<E>): Parser<A | B | C | D | E>
-export function $C<A, B, C, D, E, F>(a: Parser<A>, b: Parser<B>, c: Parser<C>, d: Parser<D>, e: Parser<E>, f: Parser<F>): Parser<A | B | C | D | E | F>
-export function $C<A, B, C, D, E, F, H>(a: Parser<A>, b: Parser<B>, c: Parser<C>, d: Parser<D>, e: Parser<E>, f: Parser<F>, h: Parser<H>): Parser<A | B | C | D | E | F | H>
-export function $C<A, B, C, D, E, F, H, I>(a: Parser<A>, b: Parser<B>, c: Parser<C>, d: Parser<D>, e: Parser<E>, f: Parser<F>, h: Parser<H>, i: Parser<I>): Parser<A | B | C | D | E | F | H | I>
-export function $C<A, B, C, D, E, F, H, I, J>(a: Parser<A>, b: Parser<B>, c: Parser<C>, d: Parser<D>, e: Parser<E>, f: Parser<F>, h: Parser<H>, i: Parser<I>, j: Parser<J>): Parser<A | B | C | D | E | F | H | I | J>
-export function $C<T extends any[]>(...terms: { [I in keyof T]: Parser<T[I]> }): Parser<T[number]>
-
 export function $C<T extends any[]>(...terms: { [I in keyof T]: Parser<T[I]> }): Parser<T[number]> {
   return (ctx, state): MaybeResult<T[number]> => {
     let i = 0
@@ -190,20 +177,6 @@ export function $C<T extends any[]>(...terms: { [I in keyof T]: Parser<T[I]> }):
  * A B C ...
  * A followed by by B followed by C followed by ...
  */
-
-export function $S(): Parser<[]>
-export function $S<A>(fn: Parser<A>): Parser<[A]>
-export function $S<A, B>(a: Parser<A>, b: Parser<B>): Parser<[A, B]>
-export function $S<A, B, C>(a: Parser<A>, b: Parser<B>, c: Parser<C>): Parser<[A, B, C]>
-export function $S<A, B, C, D>(a: Parser<A>, b: Parser<B>, c: Parser<C>, d: Parser<D>): Parser<[A, B, C, D]>
-export function $S<A, B, C, D, E>(a: Parser<A>, b: Parser<B>, c: Parser<C>, d: Parser<D>, e: Parser<E>): Parser<[A, B, C, D, E]>
-export function $S<A, B, C, D, E, F>(a: Parser<A>, b: Parser<B>, c: Parser<C>, d: Parser<D>, e: Parser<E>, f: Parser<F>): Parser<[A, B, C, D, E, F]>
-export function $S<A, B, C, D, E, F, G>(a: Parser<A>, b: Parser<B>, c: Parser<C>, d: Parser<D>, e: Parser<E>, f: Parser<F>, g: Parser<G>): Parser<[A, B, C, D, E, F, G]>
-export function $S<A, B, C, D, E, F, G, H>(a: Parser<A>, b: Parser<B>, c: Parser<C>, d: Parser<D>, e: Parser<E>, f: Parser<F>, g: Parser<G>, h: Parser<H>): Parser<[A, B, C, D, E, F, G, H]>
-export function $S<A, B, C, D, E, F, G, H, I>(a: Parser<A>, b: Parser<B>, c: Parser<C>, d: Parser<D>, e: Parser<E>, f: Parser<F>, g: Parser<G>, h: Parser<H>, i: Parser<I>): Parser<[A, B, C, D, E, F, G, H, I]>
-export function $S<A, B, C, D, E, F, G, H, I, J>(a: Parser<A>, b: Parser<B>, c: Parser<C>, d: Parser<D>, e: Parser<E>, f: Parser<F>, g: Parser<G>, h: Parser<H>, i: Parser<I>, j: Parser<J>): Parser<[A, B, C, D, E, F, G, H, I, J]>
-export function $S<T extends any[]>(...terms: { [I in keyof T]: Parser<T[I]> }): Parser<T>
-
 export function $S<T extends any[]>(...terms: { [I in keyof T]: Parser<T[I]> }): Parser<T> {
   return (ctx, state): MaybeResult<T> => {
     let { input, pos } = state,

--- a/test/inference.fixture.hera
+++ b/test/inference.fixture.hera
@@ -14,3 +14,9 @@ Num
     value: parseInt($1),
     children: [$1],
   }
+
+LongChoice
+  ( "a" / "b" / "c" / "d" / "e" / "f" / "g" / "h" / "i" / "j" ):letter -> letter
+
+LongSequence
+  "a" "b" "c" "d" "e" "f" "g" "h" "i" "j" "k"

--- a/test/inference.test-d.ts
+++ b/test/inference.test-d.ts
@@ -1,4 +1,4 @@
-import { Mini, Block, Num } from "./inference.fixture.hera"
+import { Mini, Block, Num, LongChoice, LongSequence } from "./inference.fixture.hera"
 
 // Type-level assertion helpers, mirroring the core of TypeStrong/ts-expect.
 const expectType = <T>(_: T): void => void 0
@@ -9,6 +9,8 @@ type TypeEqual<A, B> =
 type MiniValue = NonNullable<ReturnType<typeof Mini>>["value"]
 type BlockValue = NonNullable<ReturnType<typeof Block>>["value"]
 type NumValue = NonNullable<ReturnType<typeof Num>>["value"]
+type LongChoiceValue = NonNullable<ReturnType<typeof LongChoice>>["value"]
+type LongSequenceValue = NonNullable<ReturnType<typeof LongSequence>>["value"]
 
 // Discriminator literals survive inference (not widened to `string`).
 expectType<"Block">((null as unknown as BlockValue).type)
@@ -16,6 +18,8 @@ expectType<"Num">((null as unknown as NumValue).type)
 
 // Mini is exactly the union of its alternatives' value types.
 expectType<TypeEqual<MiniValue, BlockValue | NumValue>>(true)
+expectType<TypeEqual<LongChoiceValue, "a" | "b" | "c" | "d" | "e" | "f" | "g" | "h" | "i" | "j">>(true)
+expectType<TypeEqual<LongSequenceValue, ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"]>>(true)
 
 // Discriminated narrowing: each branch only sees its own fields.
 declare const m: MiniValue


### PR DESCRIPTION
Ran into this issue in Civet where `( "some" / "every" / "count" / "first" / "sum" / "product" / "min" / "max" / "join" / "concat" )` (10 items) wasn't typed correctly.

- Add variadic public overloads for `$C` and `$S` so generated typed parsers support more than 9 choice alternatives or sequence items
- Add type-level generated-parser coverage for a 10-way choice and 11-item sequence
