### PR TITLE
Add --version flag to CLI

### DIFF
--- a/source/cli-bin.civet
+++ b/source/cli-bin.civet
@@ -7,7 +7,7 @@ path from path
 argv := process.argv
 
 if argv.includes '--version'
-  { version } := JSON.parse fs.readFileSync path.join(path.dirname(__filename), '../package.json'), 'utf8'
+  { version } := JSON.parse fs.readFileSync path.join(__dirname, '../package.json'), 'utf8'
   process.stdout.write `${version}\n`
   process.exit 0
 

--- a/source/cli-bin.civet
+++ b/source/cli-bin.civet
@@ -3,11 +3,10 @@
 fs from fs
 path from path
 { main } from ./cli.civet
-{ version } from ../package.json
-
 argv := process.argv
 
 if argv.includes '--version'
+  { version } := JSON.parse fs.readFileSync path.join(path.dirname(__filename), '../package.json'), 'utf8'
   process.stdout.write `${version}\n`
   process.exit 0
 
@@ -56,11 +55,17 @@ if positional.length > 0
     catch err
       reportError err, file
 else
-  try
-    input := fs.readFileSync process.stdin.fd, encoding
-    filename .= "<stdin>"
-    try
-      filename = fs.realpathSync '/dev/stdin'
-    process.stdout.write main argv, input, filename
-  catch err
-    reportError err
+  readStdin := (): Promise<string> ->
+    new Promise (resolve, reject) ->
+      chunks: Buffer[] := []
+      process.stdin.on 'data', (chunk: Buffer) -> chunks.push chunk
+      process.stdin.on 'end', -> resolve Buffer.concat(chunks).toString encoding
+      process.stdin.on 'error', reject
+
+  readStdin()
+    .then (input) ->
+      filename .= "<stdin>"
+      try
+        filename = fs.realpathSync '/dev/stdin'
+      process.stdout.write main argv, input, filename
+    .catch (err: unknown) -> reportError err

--- a/source/cli-bin.civet
+++ b/source/cli-bin.civet
@@ -3,6 +3,7 @@
 fs from fs
 path from path
 { main } from ./cli.civet
+
 argv := process.argv
 
 if argv.includes '--version'
@@ -55,17 +56,11 @@ if positional.length > 0
     catch err
       reportError err, file
 else
-  readStdin := (): Promise<string> ->
-    new Promise (resolve, reject) ->
-      chunks: Buffer[] := []
-      process.stdin.on 'data', (chunk: Buffer) -> chunks.push chunk
-      process.stdin.on 'end', -> resolve Buffer.concat(chunks).toString encoding
-      process.stdin.on 'error', reject
-
-  readStdin()
-    .then (input) ->
-      filename .= "<stdin>"
-      try
-        filename = fs.realpathSync '/dev/stdin'
-      process.stdout.write main argv, input, filename
-    .catch (err: unknown) -> reportError err
+  try
+    input := fs.readFileSync process.stdin.fd, encoding
+    filename .= "<stdin>"
+    try
+      filename = fs.realpathSync '/dev/stdin'
+    process.stdout.write main argv, input, filename
+  catch err
+    reportError err

--- a/source/cli-bin.civet
+++ b/source/cli-bin.civet
@@ -3,8 +3,14 @@
 fs from fs
 path from path
 { main } from ./cli.civet
+{ version } from ../package.json
 
 argv := process.argv
+
+if argv.includes '--version'
+  process.stdout.write `${version}\n`
+  process.exit 0
+
 encoding := "utf8"
 valueFlags := new Set ['--language', '--libPath', '-o', '--output']
 


### PR DESCRIPTION
## Summary
- Adds `--version` flag to the Hera CLI that prints the current package version and exits

## Test plan
- [ ] Run `hera --version` and confirm it prints the version number (e.g. `0.9.8`)
- [ ] Confirm normal compilation still works when `--version` is not passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)