### PR TITLE
Read stdin asynchronously to avoid EAGAIN on non-blocking pipes

### DIFF
--- a/source/cli-bin.civet
+++ b/source/cli-bin.civet
@@ -50,11 +50,19 @@ if positional.length > 0
     catch err
       reportError err, file
 else
-  try
-    input := fs.readFileSync process.stdin.fd, encoding
-    filename .= "<stdin>"
-    try
-      filename = fs.realpathSync '/dev/stdin'
-    process.stdout.write main argv, input, filename
-  catch err
-    reportError err
+  // fs.readFileSync(process.stdin.fd) throws EAGAIN on Node v24 when stdin
+  // is a non-blocking pipe and data isn't available yet; stream it instead.
+  readStdin := (): Promise<string> ->
+    new Promise (resolve, reject) ->
+      chunks: Buffer[] := []
+      process.stdin.on 'data', (chunk: Buffer) -> chunks.push chunk
+      process.stdin.on 'end', -> resolve Buffer.concat(chunks).toString encoding
+      process.stdin.on 'error', reject
+
+  readStdin()
+    .then (input) ->
+      filename .= "<stdin>"
+      try
+        filename = fs.realpathSync '/dev/stdin'
+      process.stdout.write main argv, input, filename
+    .catch (err: unknown) -> reportError err


### PR DESCRIPTION
## Summary
- Replaces `fs.readFileSync(process.stdin.fd)` in the CLI with async stream-based stdin reading

On Node v24, the sync read throws `EAGAIN: resource temporarily unavailable` when stdin is a non-blocking pipe and data isn't available yet at the moment of the read. Streaming via `'data'`/`'end'` events handles blocking and non-blocking stdin alike.

This change originally snuck into #97 unrelated to that PR's purpose; split out here per [discussion](https://github.com/DanielXMoore/Hera/pull/97#discussion_r3390575498).

## Test plan
- [x] Reproduced the failure on `main` (Node v24.14.1): spawning `dist/hera` with an `O_NONBLOCK` stdin pipe whose writer delays 500ms → `Error: EAGAIN: resource temporarily unavailable, read`, exit 1
- [x] Same repro against this branch: compiles successfully, exit 0
- [x] `echo <grammar> | dist/hera` (normal blocking pipe) still works
- [x] `pnpm test` (157 passing) and `pnpm test:typed-parser-samples` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)