### PR TITLE
Full ECMA-262 regex literal grammar sample

### DIFF
--- a/perf/compare.civet
+++ b/perf/compare.civet
@@ -61,7 +61,14 @@ benchOne := (name, meta) ->
   grammarSrc := fs.readFileSync path.join("samples", name), "utf8"
   input := meta.input
 
-  prevParser := compileWith prevHera, grammarSrc
+  // A sample may use grammar syntax newer than the previous release (e.g.
+  // regex.hera's ::any annotations vs 0.9.0); skip it rather than abort.
+  let prevParser
+  try
+    prevParser = compileWith prevHera, grammarSrc
+  catch
+    console.error `  skipping ${name}: previous hera cannot parse it`
+    return undefined
   currParser := compileWith currHera, grammarSrc
 
   prevSize := prevHera.compile(prevHera.parse(grammarSrc), module: false).length
@@ -100,7 +107,8 @@ timestamp := new Date().toISOString()
 
 rows: any[] := []
 for [name, meta] of Object.entries(samples)
-  rows.push benchOne(name, meta)
+  row := benchOne(name, meta)
+  rows.push row if row?
 
 // ---- format report ---------------------------------------------------------
 

--- a/samples/regex.hera
+++ b/samples/regex.hera
@@ -10,7 +10,8 @@
 #
 # This grammar is purely syntactic.  Context-dependent early errors are not
 # checked: backreferences to nonexistent groups, duplicate group names or
-# flags, out-of-order ranges like [z-a], or bounds like {3,1}.  Annex B
+# flags, out-of-order ranges like [z-a], bounds like {3,1}, or invalid
+# modifier combinations like (?ii:x), (?i-i:x), and (?-:x).  Annex B
 # (sloppy-mode) extensions such as an unmatched `{`, a lone `]`, or identity
 # escapes like \q are rejected, as in Unicode mode.  The `v` flag is
 # accepted but ClassSetExpression syntax is not (TODO).

--- a/samples/regex.hera
+++ b/samples/regex.hera
@@ -121,8 +121,11 @@ UnicodeEscapeSequence
   "u{" CodePoint "}"
   "u" HexDigit HexDigit HexDigit HexDigit
 
+# Any number of hex digits, but the value must not exceed 0x10FFFF.
+# Leading zeros are allowed (\u{0000000041} is valid JS), so strip them
+# before checking the significant digits against the ceiling.
 CodePoint
-  /[0-9a-fA-F]+/
+  /0*(?:10[0-9a-fA-F]{4}|[0-9a-fA-F]{1,5})/
 
 HexDigit
   [0-9a-fA-F]

--- a/samples/regex.hera
+++ b/samples/regex.hera
@@ -1,45 +1,189 @@
-# WIP Regex parser
-Regex
-  "/" Primary+ "/" Flags*
+# JavaScript regular expression literals, e.g. /foo[abc](?:bar)\d+/g
+#
+# The Pattern grammar follows ECMA-262 "Patterns" (https://tc39.es/ecma262/#sec-patterns)
+# in strict (Unicode-aware) form, including named groups, lookbehind,
+# \u{...} escapes, \p{...} property escapes, and (?ims-ims:...) modifiers.
+# The RegExpLiteral wrapper follows the lexical grammar
+# (https://tc39.es/ecma262/#sec-literals-regular-expression-literals):
+# an unescaped `/` may not appear outside a character class, line
+# terminators may not appear at all, and `//` is not a regex.
+#
+# This grammar is purely syntactic.  Context-dependent early errors are not
+# checked: backreferences to nonexistent groups, duplicate group names or
+# flags, out-of-order ranges like [z-a], or bounds like {3,1}.  Annex B
+# (sloppy-mode) extensions such as an unmatched `{`, a lone `]`, or identity
+# escapes like \q are rejected, as in Unicode mode.  The `v` flag is
+# accepted but ClassSetExpression syntax is not (TODO).
 
-RegexCharacter
-  /[^\/\\]+/
-  EscapeSequence
-
-Primary
-  CharacterClass ::any -> $1
-  Group ::any -> $1
-  RegexCharacter ::any -> $1
-
-Group
-  "(" GroupPrefix? Primary* ")"
-
-CharacterClass
-  "[" CharacterClassCharacter* "]"
-
-CharacterClassCharacter
-  /[^\]\\]+/
-  EscapeSequence
-
-EscapeSequence
-  Backslash /[^]/ ->
-    return '\\' + $2
-
-Backslash
-  "\\"
-
-GroupPrefix
-  GroupName
-  NonCapturing
-
-NonCapturing
-  "?:"
+RegExpLiteral
+  "/" !"/" Pattern "/" Flags
 
 Flags
-  /[dgimsuy]/
+  /[dgimsuvy]*/
+
+Pattern
+  Disjunction
+
+# ::any breaks the type-inference cycle for this recursive rule (the
+# generated parser would otherwise fail under noImplicitAny).
+Disjunction
+  Alternative ( "|" Alternative )* ::any
+
+Alternative
+  Term*
+
+Term
+  Assertion
+  Atom Quantifier?
+
+Assertion
+  "^"
+  "$"
+  "\\b"
+  "\\B"
+  "(?="  Disjunction ")"
+  "(?!"  Disjunction ")"
+  "(?<=" Disjunction ")"
+  "(?<!" Disjunction ")"
+
+Quantifier
+  QuantifierPrefix "?"?
+
+QuantifierPrefix
+  [*+?]
+  "{" DecimalDigits ( "," DecimalDigits? )? "}"
+
+DecimalDigits
+  /[0-9]+/
+
+DecimalDigit
+  [0-9]
+
+Atom
+  PatternCharacter
+  "."
+  "\\" AtomEscape
+  CharacterClass
+  "(?" Modifiers ":" Disjunction ")"
+  "(?" Modifiers "-" Modifiers ":" Disjunction ")"
+  "(" GroupSpecifier Disjunction ")"
+
+# SourceCharacter but not SyntaxCharacter (^ $ \ . * + ? ( ) [ ] { } |).
+# Also excludes `/` and line terminators, which the lexical grammar forbids
+# inside a literal.
+PatternCharacter
+  [^^$\\.*+?()\[\]{}|/\n\r\u2028\u2029]
+
+AtomEscape
+  DecimalEscape
+  CharacterClassEscape
+  CharacterEscape
+  "k" GroupName
+
+# Backreference to a numbered capture group.  (Whether the group exists is
+# a semantic check, not made here.)
+DecimalEscape
+  /[1-9][0-9]*/
+
+CharacterClassEscape
+  [dDsSwW]
+  [pP] "{" UnicodePropertyValueExpression "}"
+
+UnicodePropertyValueExpression
+  UnicodePropertyName "=" UnicodePropertyValue
+  UnicodePropertyValue
+
+UnicodePropertyName
+  /[A-Za-z_]+/
+
+UnicodePropertyValue
+  /[A-Za-z0-9_]+/
+
+CharacterEscape
+  ControlEscape
+  "c" ControlLetter
+  "0" !DecimalDigit
+  HexEscapeSequence
+  UnicodeEscapeSequence
+  IdentityEscape
+
+ControlEscape
+  [fnrtv]
+
+ControlLetter
+  [a-zA-Z]
+
+HexEscapeSequence
+  "x" HexDigit HexDigit
+
+# \uFFFF or \u{10FFFF}
+UnicodeEscapeSequence
+  "u{" CodePoint "}"
+  "u" HexDigit HexDigit HexDigit HexDigit
+
+CodePoint
+  /[0-9a-fA-F]+/
+
+HexDigit
+  [0-9a-fA-F]
+
+# In Unicode mode only SyntaxCharacter and `/` are valid identity escapes.
+# (Annex B allows almost any character.)
+IdentityEscape
+  [\^$\\.*+?()\[\]{}|/]
+
+CharacterClass
+  "[" "^"? NonemptyClassRanges? "]"
+
+# `NonemptyClassRanges?` plays the role of the spec's ClassRanges
+# (NonemptyClassRanges or empty).
+# The ::any annotations break the type-inference cycle of these mutually
+# recursive rules, like Disjunction above (every alternative needs one for
+# the rule's declared type to apply).
+NonemptyClassRanges
+  ClassAtom "-" ClassAtom NonemptyClassRanges? ::any
+  ClassAtom NonemptyClassRangesNoDash ::any
+  ClassAtom ::any
+
+NonemptyClassRangesNoDash
+  ClassAtomNoDash "-" ClassAtom NonemptyClassRanges? ::any
+  ClassAtomNoDash NonemptyClassRangesNoDash ::any
+  ClassAtom ::any
+
+ClassAtom
+  "-"
+  ClassAtomNoDash
+
+# SourceCharacter but not one of \ ] - (nor a line terminator, which the
+# lexical grammar forbids).  Note that an unescaped `/` is allowed here.
+ClassAtomNoDash
+  "\\" ClassEscape
+  [^\\\]\-\n\r\u2028\u2029]
+
+ClassEscape
+  "b"
+  "-"
+  CharacterClassEscape
+  CharacterEscape
+
+GroupSpecifier
+  ( "?" GroupName )?
 
 GroupName
-  "<" Name ">"
+  "<" RegExpIdentifierName ">"
 
-Name
-  /[a-zA-Z][a-zA-Z0-9]+/
+# (?ims:...) / (?ims-ims:...) regular expression pattern modifiers.
+# An empty Modifiers also covers plain non-capturing groups (?:...).
+Modifiers
+  /[ims]*/
+
+RegExpIdentifierName
+  RegExpIdentifierStart RegExpIdentifierContinue*
+
+RegExpIdentifierStart
+  /[\p{ID_Start}$_]/
+  "\\" UnicodeEscapeSequence
+
+RegExpIdentifierContinue
+  /[\p{ID_Continue}$\u200C\u200D]/ # ID_Continue, $, <ZWNJ>, <ZWJ>
+  "\\" UnicodeEscapeSequence

--- a/test/regex.civet
+++ b/test/regex.civet
@@ -27,6 +27,7 @@ valid := [
   '/\\p{Script=Latin}+\\P{L}/u'
   '/\\u{1F600}|\\uD83D\\uDE00/u'
   '/\\u{10FFFF}/u'
+  '/\\u{0}\\u{00}\\u{0000000041}\\u{000010FFFF}/u' // leading zeros are fine
   '/a{2}b{3,}c{4,5}d{5,6}?/'
   '/x*?y+?z??/'
   '/[\\b\\-a-z\\u200C]/u'
@@ -56,6 +57,10 @@ invalid := [
   '/[\\B]/'
   '/\\x1/'
   '/\\u12/'
+  '/\\u{110000}/u' // code point above 0x10FFFF
+  '/\\u{1FFFFF}/u'
+  '/\\u{000110000}/u' // leading zeros don't hide an out-of-range value
+  '/\\u{}/u'
   '/\\k/'
   '/(?<1a>x)/'
   '/(?<name>x/'

--- a/test/regex.civet
+++ b/test/regex.civet
@@ -1,0 +1,78 @@
+assert from assert
+{ readFile } from ./helper.civet
+{ generate } from ../source/main.civet
+
+// samples/regex.hera parses JavaScript regular expression literals using the
+// ECMA-262 Pattern grammar in strict (Unicode-aware) form.  Every accepted
+// literal is cross-checked against the real JS engine.  Rejected literals
+// are invalid in Unicode mode (some are tolerated by Annex B sloppy mode —
+// the grammar intentionally sides with strict mode; see the grammar header).
+
+parser := generate readFile "samples/regex.hera"
+
+valid := [
+  '/a/'
+  '/ /'
+  '/=/'
+  '/(?:)/'
+  '/[]/'
+  '/foo[abc](?:bar)\\d+/g' // the input used by perf/compare.civet
+  '/^https?:\\/\\/[^\\s/$.?#]+[^\\s]*$/i'
+  '/(\\d{4})-(\\d{2})-(\\d{2})/'
+  '/(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})/u'
+  '/(?<tag><[a-z]+>).*?\\k<tag>/'
+  '/^[a-zA-Z_$][a-zA-Z0-9_$]*$/'
+  '/a|b|/'
+  '/(?=x)(?!y)(?<=z)(?<!w)x/'
+  '/\\p{Script=Latin}+\\P{L}/u'
+  '/\\u{1F600}|\\uD83D\\uDE00/u'
+  '/\\u{10FFFF}/u'
+  '/a{2}b{3,}c{4,5}d{5,6}?/'
+  '/x*?y+?z??/'
+  '/[\\b\\-a-z\\u200C]/u'
+  '/[-a][a-][\\]][/][^abc][\\d\\w]/'
+  '/(?i:x)(?m-i:y)(?-s:z)/'
+  '/\\0\\x41\\u0041\\n\\cA\\$\\./'
+  '/(a(b(c)))\\1\\2\\3/'
+  '/((((((((((a))))))))))/'
+  '/./dgimsuy'
+]
+
+// All of these are SyntaxErrors in Unicode mode.  Those marked Annex B are
+// accepted by sloppy mode JS but rejected by this grammar (strict view).
+invalid := [
+  '//' // a comment, not a regex
+  '/+/'
+  '/a**/'
+  '/^*/'
+  '/(/'
+  '/a)/'
+  '/[a/'
+  '/a{1,2,}/' // Annex B treats {1,2,} as literal characters
+  '/a{/' // Annex B
+  '/]/' // Annex B
+  '/\\q/' // Annex B identity escape
+  '/\\01/' // Annex B legacy octal
+  '/[\\B]/'
+  '/\\x1/'
+  '/\\u12/'
+  '/\\k/'
+  '/(?<1a>x)/'
+  '/(?<name>x/'
+  '/(?=x/'
+  '/(?i_:x)/'
+  '/a\nb/' // literal line terminator
+  '/a/z' // invalid flag
+]
+
+describe "regex sample (ECMA-262 RegExp literals)", ->
+  for literal of valid
+    it `accepts ${JSON.stringify(literal)}`, ->
+      parser.parse literal
+      // cross-check: the JS engine agrees this is a valid regex literal
+      re := new Function(`return ${literal}`)()
+      assert re instanceof RegExp
+
+  for literal of invalid
+    it `rejects ${JSON.stringify(literal)}`, ->
+      assert.throws -> parser.parse literal


### PR DESCRIPTION
Ports the ECMA-262 regex grammar from #11 onto current main, fixed up so it compiles and parses accurately.

## What changed from the #11 version

- **Fixed `PatternCharacter` not excluding `\`** — escapes never parsed via `AtomEscape`; a trailing lone backslash was silently accepted
- **Added the missing `DecimalDigits` rule** (was an undefined reference)
- **Removed the unfinished proposal sections** — the set-notation rules contained pasted spec prose (`[lookahead ∉ ClassReservedDouble] SourceCharacter but not ...`) referencing undefined rules, and the trailing modifiers `Atom` rule duplicated (and would clobber) the real `Atom`
- **Fixed `QuantifierPrefix`** to reject `{1,2,}` (was `( "," DecimalDigits )? ","?`)
- **Strict-mode alignment**: `IdentityEscape` restricted to SyntaxCharacter / `/`, `\0` requires no following digit, Annex B forms (`a{`, lone `]`, `\q`, legacy octal) rejected

## Modernized

- `\u{...}` code point escapes, `\p{...}`/`\P{...}` property escapes (hera compiles terminals with the `u` flag, so these work natively)
- ES2025 pattern modifiers `(?ims-ims:...)` — now standard, integrated into `Atom` (subsumes `(?:`)
- Named groups, `\k<name>`, lookbehind kept from #11

The start rule is now `RegExpLiteral` (`/pattern/flags` per the lexical grammar — unescaped `/` only inside classes, no line terminators, `//` is not a regex), which keeps the `perf/compare.civet` input `/foo[abc](?:bar)\d+/g` parsing.

Set-notation (`v`-flag `ClassSetExpression`) syntax is left as a TODO; the flag itself is accepted.

## Testing

`test/regex.civet`: 25 valid literals — every accepted literal is cross-checked against the JS engine via `new Function` — and 22 rejections (each a SyntaxError in Unicode mode). Recursive rules carry `::any` annotations so the generated parser passes the strict `tsc -p tsconfig.parsers.json` check.

Note: `pnpm test:typed-parser-samples` currently fails on main locally on `inference.fixture.hera` (`$C`/`$S` overload arity); unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)