### PR TITLE
Compose sourcemaps in two-stage register hooks

### DIFF
--- a/build/esbuild.civet
+++ b/build/esbuild.civet
@@ -79,6 +79,7 @@ esbuild.build {
     "source/machine.civet"
     "source/register.civet"
     "source/register/cjs.civet"
+    "source/register/sourcemap.civet"
     "source/register/tsc/cjs.civet"
     "source/register/tsc/esm.civet"
     "source/register/tsc/index.civet"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "@danielx/civet": "0.11.6",
     "@danielx/hera-previous": "npm:@danielx/hera@0.9.0",
+    "@jridgewell/trace-mapping": "0.3.31",
     "@types/mocha": "^10.0.10",
     "@types/node": "^25.5.2",
     "benchmark": "^2.1.4",
@@ -102,5 +103,8 @@
     "./hera-types": "./dist/hera-types.js"
   },
   "types": "dist/main.d.ts",
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@10.33.0",
+  "dependencies": {
+    "@jridgewell/remapping": "2.3.5"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@jridgewell/remapping':
+        specifier: 2.3.5
+        version: 2.3.5
     devDependencies:
       '@danielx/civet':
         specifier: 0.11.6
@@ -14,6 +18,9 @@ importers:
       '@danielx/hera-previous':
         specifier: npm:@danielx/hera@0.9.0
         version: '@danielx/hera@0.9.0'
+      '@jridgewell/trace-mapping':
+        specifier: 0.3.31
+        version: 0.3.31
       '@types/mocha':
         specifier: ^10.0.10
         version: 10.0.10

--- a/source/register/civet/transpile.civet
+++ b/source/register/civet/transpile.civet
@@ -1,5 +1,8 @@
 { createRequire } from 'module'
 type { CompileOptions } from '@danielx/civet'
+type { SourceMapInput } from '@jridgewell/remapping'
+
+{ extractInlineMap, composedInlineMapComment } from ../sourcemap.civet
 
 // createRequire needs a base path for peer dep resolution.
 // process.cwd() is available in both ESM (tests) and CJS (production),
@@ -24,11 +27,19 @@ export compileCivetToJs := (src: string, filename?: string, civetOptions?: Compi
         "[@danielx/hera] Civet support requires '@danielx/civet' to be installed."
         "Run: npm install @danielx/civet"
       ].join '\n'
-  options := { ...civetOptions, ...(filename and { filename }), js: true, sync: true }
-  result := civet.compile(src, options)
+  // If the input carries an inline map (e.g. hera -> Civet from the Hera
+  // compiler) it would be stale after compiling shifts line numbers, so
+  // strip it and have Civet emit a Civet -> JS map to compose with it.
+  { code: civetSource, map: inputMap } := extractInlineMap src
+
+  options := { ...civetOptions, ...(filename and { filename }), js: true, sync: true, ...(inputMap and { sourceMap: true }) }
+  // The cast through unknown is because TS infers a Promise result despite sync: true
+  result := civet.compile(civetSource, options) as unknown as string | { code: string, sourceMap?: { json(outFileName: string): unknown } }
 
   if result <? 'string'
     result
+  else if inputMap and result.sourceMap
+    map := result.sourceMap.json(filename ?? "anonymous") as SourceMapInput
+    `${result.code}\n${composedInlineMapComment map, inputMap}\n`
   else
-    // @ts-expect-error TODO: Figure out why it thinks result is a promise and not a string or object even though sync: true
     result.code

--- a/source/register/civet/transpile.civet
+++ b/source/register/civet/transpile.civet
@@ -1,8 +1,7 @@
 { createRequire } from 'module'
 type { CompileOptions } from '@danielx/civet'
-type { SourceMapInput } from '@jridgewell/remapping'
 
-{ extractInlineMap, composedInlineMapComment } from ../sourcemap.civet
+{ hasInlineMap } from ../sourcemap.civet
 
 // createRequire needs a base path for peer dep resolution.
 // process.cwd() is available in both ESM (tests) and CJS (production),
@@ -28,18 +27,17 @@ export compileCivetToJs := (src: string, filename?: string, civetOptions?: Compi
         "Run: npm install @danielx/civet"
       ].join '\n'
   // If the input carries an inline map (e.g. hera -> Civet from the Hera
-  // compiler) it would be stale after compiling shifts line numbers, so
-  // strip it and have Civet emit a Civet -> JS map to compose with it.
-  { code: civetSource, map: inputMap } := extractInlineMap src
-
-  options := { ...civetOptions, ...(filename and { filename }), js: true, sync: true, ...(inputMap and { sourceMap: true }) }
+  // compiler) it would be stale after compiling shifts line numbers. Civet
+  // strips a trailing inline map from its input, adopts it as the upstream
+  // map, and composes it with its own Civet -> JS map when we ask for an
+  // inline map (`upstreamSourceMap ??= sm` in @danielx/civet's compile), so
+  // the emitted map points back at the original source. Without an input map
+  // we leave the output map-free, matching prior behavior.
+  options := { ...civetOptions, ...(filename and { filename }), js: true, sync: true, ...(hasInlineMap(src) and { inlineMap: true }) }
   // The cast through unknown is because TS infers a Promise result despite sync: true
-  result := civet.compile(civetSource, options) as unknown as string | { code: string, sourceMap?: { json(outFileName: string): unknown } }
+  result := civet.compile(src, options) as unknown as string | { code: string }
 
   if result <? 'string'
     result
-  else if inputMap and result.sourceMap
-    map := result.sourceMap.json(filename ?? "anonymous") as SourceMapInput
-    `${result.code}\n${composedInlineMapComment map, inputMap}\n`
   else
     result.code

--- a/source/register/sourcemap.civet
+++ b/source/register/sourcemap.civet
@@ -14,6 +14,13 @@ remapping, { type SourceMapInput } from @jridgewell/remapping
 inlineMapPattern := new RegExp `\\n${"//#"} sourceMappingURL=data:application/json;base64,([A-Za-z0-9+/=]+)\\s*$`
 
 /**
+ * Whether the source ends with an inline sourcemap comment. Used to decide
+ * whether to ask the next stage to emit (and compose) a map of its own.
+ */
+export function hasInlineMap(source: string): boolean
+  inlineMapPattern.test source
+
+/**
  * Split a trailing inline sourcemap comment off of compiled source.
  * Returns the source without the comment and the decoded map, if any.
  */

--- a/source/register/sourcemap.civet
+++ b/source/register/sourcemap.civet
@@ -20,10 +20,15 @@ inlineMapPattern := new RegExp `\\n${"//#"} sourceMappingURL=data:application/js
 export function extractInlineMap(source: string): { code: string, map?: SourceMapInput }
   match := source.match inlineMapPattern
   return { code: source } unless match
-  {
-    code: source.slice 0, match.index
-    map: JSON.parse Buffer.from(match[1], "base64").toString("utf8")
-  }
+  // A malformed map comment degrades to the no-map pass-through rather than
+  // crashing the register hook at file-load time
+  try
+    {
+      code: source.slice 0, match.index
+      map: JSON.parse Buffer.from(match[1], "base64").toString("utf8")
+    }
+  catch
+    { code: source }
 
 /**
  * Compose a second-stage map (e.g. TS -> JS) with a first-stage map

--- a/source/register/sourcemap.civet
+++ b/source/register/sourcemap.civet
@@ -1,0 +1,35 @@
+// Sourcemap composition helpers for the two-stage register hooks.
+//
+// The Hera compiler attaches an inline map (hera -> TS or hera -> Civet) to
+// its output. When a second stage (tsc or Civet) transpiles that output to
+// JS, line numbers shift, so the second stage must produce its own map and
+// compose it with the first or stack traces and coverage attribute to the
+// wrong lines.
+
+remapping, { type SourceMapInput } from @jridgewell/remapping
+
+// Matches a trailing inline sourcemap comment like the one the Hera compiler
+// appends (the "//" + "#" split prevents tools from picking this line up as
+// an actual sourceMappingURL)
+inlineMapPattern := new RegExp `\\n${"//#"} sourceMappingURL=data:application/json;base64,([A-Za-z0-9+/=]+)\\s*$`
+
+/**
+ * Split a trailing inline sourcemap comment off of compiled source.
+ * Returns the source without the comment and the decoded map, if any.
+ */
+export function extractInlineMap(source: string): { code: string, map?: SourceMapInput }
+  match := source.match inlineMapPattern
+  return { code: source } unless match
+  {
+    code: source.slice 0, match.index
+    map: JSON.parse Buffer.from(match[1], "base64").toString("utf8")
+  }
+
+/**
+ * Compose a second-stage map (e.g. TS -> JS) with a first-stage map
+ * (e.g. hera -> TS), producing a map from the original source to the final
+ * JS, and return it as an inline sourcemap comment to append to the JS.
+ */
+export function composedInlineMapComment(secondStageMap: SourceMapInput, firstStageMap: SourceMapInput): string
+  composed := remapping [secondStageMap, firstStageMap], => null
+  `${"//#"} sourceMappingURL=data:application/json;base64,${Buffer.from(JSON.stringify(composed), "utf8").toString("base64")}`

--- a/source/register/tsc/transpile.civet
+++ b/source/register/tsc/transpile.civet
@@ -1,5 +1,7 @@
 typescript from typescript
 
+{ extractInlineMap, composedInlineMapComment } from ../sourcemap.civet
+
 export CompilerOptions ::= typescript.TranspileOptions['compilerOptions']
 LogFn ::= (...args: any[]) => any
 
@@ -15,12 +17,21 @@ export function transpileTsToJs(
   compilerOptions: CompilerOptions = {}
   log: LogFn = console.error
 )
+  // If the input carries an inline map (e.g. hera -> TS from the Hera
+  // compiler) it would be stale after transpiling shifts line numbers, so
+  // strip it and have tsc emit a TS -> JS map to compose with it instead.
+  { code, map: inputMap } := extractInlineMap tsSource
+
   compilerOptions = {
     ...defaultCompilerOptions
     ...compilerOptions
+    ...inputMap and {
+      sourceMap: true
+      inlineSourceMap: false
+    }
   }
 
-  { outputText, diagnostics } := typescript.transpileModule(tsSource, {
+  { outputText, sourceMapText, diagnostics } := typescript.transpileModule(code, {
     reportDiagnostics: true
     compilerOptions
   })
@@ -43,4 +54,9 @@ export function transpileTsToJs(
     if diagnostics.find(&.category === typescript.DiagnosticCategory.Error)
       throw new Error "TypeScript compilation failed"
 
-  outputText
+  return outputText unless inputMap and sourceMapText
+
+  // With sourceMap enabled tsc appends a comment pointing at a .js.map file
+  // that doesn't exist; replace it with the composed inline map.
+  js := outputText.replace /\n\/\/# sourceMappingURL=\S*\s*$/, ""
+  `${js}\n${composedInlineMapComment JSON.parse(sourceMapText), inputMap}\n`

--- a/source/register/tsc/transpile.civet
+++ b/source/register/tsc/transpile.civet
@@ -58,5 +58,5 @@ export function transpileTsToJs(
 
   // With sourceMap enabled tsc appends a comment pointing at a .js.map file
   // that doesn't exist; replace it with the composed inline map.
-  js := outputText.replace /\n\/\/# sourceMappingURL=\S*\s*$/, ""
+  js := outputText.replace /\r?\n\/\/# sourceMappingURL=\S*\s*$/, ""
   `${js}\n${composedInlineMapComment JSON.parse(sourceMapText), inputMap}\n`

--- a/test/register/civet/transpile.civet
+++ b/test/register/civet/transpile.civet
@@ -1,6 +1,9 @@
 assert from assert
 { mock } from node:test
 { compileCivetToJs, runtime } from ../../../source/register/civet/transpile.civet
+{ compile } from ../../../source/main.civet
+{ readFile } from ../../helper.civet
+{ TraceMap, originalPositionFor } from @jridgewell/trace-mapping
 
 describe "compileCivetToJs", ->
   it "should compile Civet const declaration to JavaScript", ->
@@ -41,3 +44,47 @@ describe "compileCivetToJs", ->
     )
 
     restore.mock.restore()
+
+  describe "sourcemap composition", ->
+    // Handler fragments that appear verbatim and uniquely in source/hera.hera
+    probes := [
+      `f: $1.join("").trimEnd(),`
+      `return $1 + $2.join("") + ($3 ?? "")`
+    ]
+
+    lineOf := (text: string, probe: string) ->
+      line := text.split("\n").findIndex(&.includes probe) + 1
+      assert line > 0, `probe ${JSON.stringify probe} not found`
+      line
+
+    it "should compose the hera->Civet map with the Civet->JS map so JS lines map back to the .hera source", ->
+      // Civet-compiling the full generated hera.hera parser takes ~1s
+      @timeout 20000
+      heraSource := readFile "source/hera.hera"
+      civetCode := compile heraSource, { filename: "source/hera.hera", inlineMap: true, language: 'civet' }
+      js := compileCivetToJs civetCode, "source/hera.hera"
+
+      // exactly one inline map: the stale hera->Civet map is stripped and
+      // replaced by the composed hera->JS map
+      assert.equal js.match(/\/\/# sourceMappingURL=/g)?#, 1
+
+      encoded := js.match(/\/\/# sourceMappingURL=data:application\/json;base64,([A-Za-z0-9+/=]+)/)![1]
+      map := JSON.parse Buffer.from(encoded, "base64").toString("utf8")
+      assert.deepEqual map.sources, ["source/hera.hera"]
+
+      tracer := new TraceMap map
+      jsLines := js.split "\n"
+      for probe of probes
+        heraLine := lineOf heraSource, probe
+        civetLine := lineOf civetCode, probe
+        jsLine := lineOf js, probe
+        // Civet emit shifts line numbers; without a shift a stale map would
+        // accidentally pass the alignment check below
+        assert civetLine !== jsLine, "expected Civet emit to shift the probe line"
+        pos := originalPositionFor tracer, { line: jsLine, column: jsLines[jsLine-1].indexOf probe }
+        assert.equal pos.source, "source/hera.hera"
+        assert.equal pos.line, heraLine
+
+    it "should not attach a map when the input has none", ->
+      js := compileCivetToJs "x := 1"
+      assert.doesNotMatch js, /sourceMappingURL/

--- a/test/register/tsc/transpile.civet
+++ b/test/register/tsc/transpile.civet
@@ -81,3 +81,9 @@ describe "transpileTsToJs", ->
     it "should not attach a map when the input has none", ->
       js := transpileTsToJs "const a: number = 1"
       assert.doesNotMatch js, /sourceMappingURL/
+
+    it "should pass through a malformed inline map rather than throw", ->
+      // "bm90anNvbg==" decodes to "notjson"
+      ts := `const a: number = 1\n//# sourceMappingURL=data:application/json;base64,bm90anNvbg==`
+      js := transpileTsToJs ts
+      assert.match js, /const a = 1/

--- a/test/register/tsc/transpile.civet
+++ b/test/register/tsc/transpile.civet
@@ -1,6 +1,9 @@
 assert from assert
 { transpileTsToJs } from ../../../source/register/tsc/transpile.civet
 typescript from typescript
+{ compile } from ../../../source/main.civet
+{ readFile } from ../../helper.civet
+{ TraceMap, originalPositionFor } from @jridgewell/trace-mapping
 
 describe "transpileTsToJs", ->
   function removeSourceMap(sourceCode: string)
@@ -36,3 +39,45 @@ describe "transpileTsToJs", ->
     // Multiple erros should be logged
     assert.match logged, /Expression expected/
     assert.match logged, /Unexpected keyword or identifier/
+
+  describe "sourcemap composition", ->
+    // Handler fragments that appear verbatim and uniquely in source/hera.hera
+    probes := [
+      `f: $1.join("").trimEnd(),`
+      `return $1 + $2.join("") + ($3 ?? "")`
+    ]
+
+    lineOf := (text: string, probe: string) ->
+      line := text.split("\n").findIndex(&.includes probe) + 1
+      assert line > 0, `probe ${JSON.stringify probe} not found`
+      line
+
+    it "should compose the hera->TS map with TS emit so JS lines map back to the .hera source", ->
+      heraSource := readFile "source/hera.hera"
+      ts := compile heraSource, { filename: "source/hera.hera", inlineMap: true }
+      js := transpileTsToJs ts
+
+      // exactly one inline map: the stale hera->TS map is stripped and
+      // replaced by the composed hera->JS map
+      assert.equal js.match(/\/\/# sourceMappingURL=/g)?#, 1
+
+      encoded := js.match(/\/\/# sourceMappingURL=data:application\/json;base64,([A-Za-z0-9+/=]+)/)![1]
+      map := JSON.parse Buffer.from(encoded, "base64").toString("utf8")
+      assert.deepEqual map.sources, ["source/hera.hera"]
+
+      tracer := new TraceMap map
+      jsLines := js.split "\n"
+      for probe of probes
+        heraLine := lineOf heraSource, probe
+        tsLine := lineOf ts, probe
+        jsLine := lineOf js, probe
+        // TS emit shifts line numbers; without a shift a stale map would
+        // accidentally pass the alignment check below
+        assert tsLine !== jsLine, "expected TS emit to shift the probe line"
+        pos := originalPositionFor tracer, { line: jsLine, column: jsLines[jsLine-1].indexOf probe }
+        assert.equal pos.source, "source/hera.hera"
+        assert.equal pos.line, heraLine
+
+    it "should not attach a map when the input has none", ->
+      js := transpileTsToJs "const a: number = 1"
+      assert.doesNotMatch js, /sourceMappingURL/


### PR DESCRIPTION
## Problem

The `register/tsc` and `register/civet` hooks compile `.hera` files with `{ inlineMap: true }` — a map from generated TS/Civet back to the hera source — then transpile that output to JS without regenerating the map. Emit shifts line numbers (−85 lines for `hera.hera` through tsc with 0.9.8 codegen; +3 through Civet), ~~so the stale inline map is misaligned against the JS that actually executes.~~ breaking source attribution for the JS that actually executes. The two stages fail **differently**:

- **tsc path:** `ts.transpileModule` regenerates nothing, so the original hera→TS inline map survives unchanged and is misaligned against the shifted JS — a *stale* map.
- **civet path:** ~~the identical flaw — the stale map comment was passed through verbatim.~~ `@danielx/civet`'s `compile` already auto-strips a trailing inline map from its input (`options.upstreamSourceMap ??= sm`), so the original hook — which requested no output map — emitted JS with **no** sourcemap at all. *Missing* attribution, not stale.

Consequences:
- Stack traces through `.hera` files point at the wrong lines (or nowhere, on the civet path).
- c8 coverage attribution for `source/hera.hera` is garbage in every version — it accidentally reported 100% under the 0.9.0 pin and drops to ~94.7% lines / 30% branches under 0.9.8, which is what blocks bumping the `@danielx/hera-previous` pin (see #99).

Reproduced before the fix: the `HandlingExpressionBody` handler line `$1.join("").trimEnd()` (`source/hera.hera:147`) sits at line 661 of the generated TS but line 576 of the emitted JS, and the stale map returns `source: null` for that JS position.

## Fix

- New `source/register/sourcemap.civet`: strips/decodes a trailing inline-map comment and composes two maps with `@jridgewell/remapping`, re-encoding inline. Also exports a `hasInlineMap` presence check.
- `transpileTsToJs`: when the input carries an inline map, strip it, run `ts.transpileModule` with `sourceMap: true`, drop tsc's dangling `//# sourceMappingURL=module.js.map` comment, and attach the composed hera → JS map. Covers both the cjs and esm paths.
- `compileCivetToJs`: ~~same composition using Civet's `sourceMap: true` output (the civet hook had the identical flaw — it passed the stale map comment through verbatim).~~ relies on Civet's **native** composition. Civet's `compile` auto-strips a trailing inline map from its input and adopts it as the upstream map (`options.upstreamSourceMap ??= sm`); requesting `{ inlineMap: true }` then composes that upstream map with Civet's own Civet→JS map and emits a single hera→JS inline map. The hook only checks whether the input has a map (so map-free inputs stay untouched) and passes the raw source through — no manual `@jridgewell/remapping` step on this path.
- Inputs without an inline map behave exactly as before.
- `@jridgewell/remapping` becomes the package's first runtime dependency — required by the **tsc path**, which (unlike Civet) has no native map composition. Already in the tree transitively, but the dist register files are unbundled so it must be declared. `@jridgewell/trace-mapping` added as a devDependency for tests.

## Verification

- After the fix, decoding the composed map confirms the probe JS lines map back to `source/hera.hera:147` / `:160` on both the tsc and civet paths.
- Regression tests in `test/register/{tsc,civet}/transpile.civet` compile `source/hera.hera`, assert exactly one inline map survives (the stale one is stripped), assert emit actually shifted the probe lines (so a stale map cannot pass accidentally), and assert two handler lines map back to their `.hera` lines.
- End-to-end: with mocha's require hook pointed at the local `dist/register/tsc`, the suite passes self-bootstrapped on 0.9.8 codegen and `hera.hera` reports a genuine 100% statements/branches/lines.
- `pnpm build && pnpm test` green at the existing 100% thresholds with the pin still at 0.9.0.

## Follow-up

Once this ships in a release, bump `@danielx/hera-previous` to it — that restores `samples/regex.hera` to the benchmark table and may surface genuinely uncovered handler branches in `hera.hera` needing real tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
