### PR TITLE
Vendor source map generator to drop Civet from main bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to `@danielx/hera` will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- `dist/main.js` no longer bundles the Civet compiler. The source map
+  generator it used is now a small vendored module, shrinking the main bundle
+  from ~990 KB to ~77 KB. Generated source maps are unchanged.
+
 ### Fixed
 - Type declarations for `$C` and `$S` now support generated parsers with more
   than 9 choice alternatives or sequence items.

--- a/source/compiler.civet
+++ b/source/compiler.civet
@@ -710,7 +710,6 @@ export function compile(rules: HeraRules, maybeOptions?: CompilerOptions): strin
       throw new Error "sourceMap requires source"
 
     sm = new SourceMap(options.source, options.filename!)
-    //@ts-expect-error
     genOpts.updateSourceMap = sm.updateSourceMap.bind(sm)
 
   head := if types

--- a/source/sourcemap.civet
+++ b/source/sourcemap.civet
@@ -1,6 +1,131 @@
-//@ts-expect-error
-{ SourceMap, sourcemap } from "@danielx/civet"
+// Minimal source map generator, adapted from @danielx/civet's sourcemap.civet.
+//
+// Only the pieces the Hera compiler needs are kept: appending output while
+// tracking the source position, and rendering a v3 JSON map.  Vendoring this
+// instead of importing it from Civet keeps the whole Civet compiler out of
+// the `dist/main.js` bundle.
 
-{ base64Encode } := sourcemap
+/** A mapping entry: [colDelta] or [colDelta, sourceIndex, srcLine, srcCol]. */
+export type SourceMapEntry = [number] | [number, number, number, number]
 
-export { SourceMap, base64Encode }
+export type SourceMapJSON = {
+  version: 3
+  file: string
+  sources: string[]
+  mappings: string
+  names: string[]
+  sourcesContent: string[]
+}
+
+EOL := /\r?\n|\r/
+BASE64_CHARS := "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+VLQ_SHIFT := 5
+VLQ_CONTINUATION_BIT := 1 << VLQ_SHIFT
+VLQ_VALUE_MASK := VLQ_CONTINUATION_BIT - 1
+
+/**
+Table of end offsets (exclusive) for each line of `input`, used to convert a
+position into line/column.
+*/
+locationTable := (input: string): number[] ->
+  linesRe := /([^\r\n]*)(\r\n|\r|\n|$)/y
+  lines: number[] := []
+  pos .= 0
+
+  while match := linesRe.exec input
+    pos += match[0].length
+    lines.push pos
+    break if pos is input.length
+
+  lines
+
+lookupLineColumn := (table: number[], pos: number): [number, number] ->
+  line .= 0
+  prevEnd .= 0
+  while table[line] <= pos
+    prevEnd = table[line++]
+  [line, pos - prevEnd]
+
+encodeVlq := (value: number): string ->
+  signBit := value < 0 ? 1 : 0
+  valueToEncode .= (Math.abs(value) << 1) + signBit
+  answer .= ""
+
+  while valueToEncode or !answer
+    nextChunk .= valueToEncode & VLQ_VALUE_MASK
+    valueToEncode >>= VLQ_SHIFT
+    nextChunk |= VLQ_CONTINUATION_BIT if valueToEncode
+    answer += BASE64_CHARS[nextChunk]
+
+  answer
+
+export base64Encode := (src: string): string ->
+  Buffer.from(src).toString "base64"
+
+export class SourceMap
+  lines: SourceMapEntry[][] = [[]]
+  line = 0
+  colOffset = 0
+  srcLine = 0
+  srcColumn = 0
+  srcTable: number[]
+
+  @(public source: string, public sourceFileName: string)
+    @srcTable = locationTable source
+
+  renderMappings(): string
+    lastSourceLine .= 0
+    lastSourceColumn .= 0
+
+    @lines.map (line) ->
+      line.map (entry) ->
+        if entry.length is 4
+          [colDelta, sourceFileIndex, srcLine, srcCol] := entry
+          lineDelta := srcLine - lastSourceLine
+          colDeltaSrc := srcCol - lastSourceColumn
+          lastSourceLine = srcLine
+          lastSourceColumn = srcCol
+          `${encodeVlq colDelta}${encodeVlq sourceFileIndex}${encodeVlq lineDelta}${encodeVlq colDeltaSrc}`
+        else
+          encodeVlq entry[0]
+      .join ","
+    .join ";"
+
+  json(outFileName: string): SourceMapJSON
+    version: 3
+    file: outFileName
+    sources: [@sourceFileName]
+    mappings: @renderMappings()
+    names: []
+    sourcesContent: [@source]
+
+  /**
+  Append `outputStr` to the generated output.  When `inputPos` is given, the
+  appended text maps back to that position in the source (plus `colOffset`).
+  */
+  updateSourceMap(outputStr: string, inputPos?: number, colOffset = 0): void
+    outLines := outputStr.split EOL
+    let srcLine = 0, srcCol = 0
+
+    if inputPos?
+      [srcLine, srcCol] = lookupLineColumn @srcTable, inputPos
+      srcCol += colOffset
+      @srcLine = srcLine
+      @srcColumn = srcCol
+
+    for each line, i of outLines
+      if i > 0
+        @line++
+        @srcLine++
+        @colOffset = 0
+        @lines[@line] = []
+        @srcColumn = srcCol = colOffset
+
+      l := @colOffset
+      @colOffset = line.length
+      @srcColumn += line.length
+
+      if inputPos?
+        @lines[@line].push [l, 0, srcLine + i, srcCol]
+      else if l is not 0
+        @lines[@line].push [l]


### PR DESCRIPTION
## Summary

- `source/sourcemap.civet` imported `SourceMap` and `base64Encode` from `@danielx/civet`. Because `main.civet` is built with `bundle: true`, esbuild inlined the entire Civet compiler (~24k lines) into `dist/main.js`.
- Replaces it with a minimal `SourceMap` class adapted from Civet's implementation, keeping only what the Hera compiler uses: appending output while tracking source positions, and rendering a v3 JSON map. The `lines` field stays public since tests inspect it.
- `dist/main.js` shrinks from 992 KB to 77 KB.
- Vendoring rather than marking Civet `external` keeps `@danielx/civet` optional: only the civet loader and the esbuild plugin's civet mode need it, and both already load it lazily.
- Drops a `@ts-expect-error` in `compiler.civet` that only existed because the Civet import was untyped.

## Test plan

- [x] Source maps (`sourceMap: true` JSON and `inlineMap: true` output) are byte-identical to the previous build for `source/hera.hera`, `samples/heregex.hera`, and `samples/math.hera`
- [x] `c8 mocha` — 209 passing, 100% coverage including the new module
- [x] `pnpm test:typed-parser-samples`
- [x] `pnpm test:esbuild-plugin`
- [x] `pnpm test:loaders`
- [x] `grep @danielx/civet dist/*.js` only hits `esbuild.js` and `register/civet/transpile.js`, the intentional lazy loaders

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6RAoyCaAv1Xe7FjMYwD3b
