### PR TITLE
Tidy util, CLI, loaders, and grammar handlers

### DIFF
--- a/source/cli-bin.civet
+++ b/source/cli-bin.civet
@@ -2,7 +2,7 @@
 
 fs from fs
 path from path
-{ main } from ./cli.civet
+{ main, getOptValue } from ./cli.civet
 
 argv := process.argv
 
@@ -26,12 +26,7 @@ while i < argv.length
     positional.push arg
     i += 1
 
-getOptValue := (opt: string) ->
-  index := argv.indexOf opt
-  if index > -1
-    argv[index + 1]
-
-outputDir := getOptValue('-o') ?? getOptValue('--output')
+outputDir := getOptValue(argv, '-o') ?? getOptValue(argv, '--output')
 
 reportError := (err: unknown, file?: string): never ->
   msg := if err instanceof Error then err.message else String(err)

--- a/source/cli.civet
+++ b/source/cli.civet
@@ -1,6 +1,14 @@
 { compile, parse, grammarToEBNF } from ./main.civet
 type { CompilerOptions } from ./compiler.civet
 
+/**
+Value following `opt` in `argv`, if present
+*/
+export getOptValue := (argv: string[], opt: string): string | undefined ->
+  index := argv.indexOf opt
+  if index > -1
+    argv[index + 1]
+
 export main := (argv: string[], input: string, filename: string = "<stdin>"): string ->
   ast := parse input
 
@@ -10,12 +18,7 @@ export main := (argv: string[], input: string, filename: string = "<stdin>"): st
   if argv.includes '--ebnf'
     return grammarToEBNF(ast)
 
-  getOptValue := (opt: string) ->
-    index := argv.indexOf opt
-    if index > -1
-      argv[index + 1]
-
-  language := getOptValue('--language') as 'javascript' | 'typescript' | 'civet' | undefined
+  language := getOptValue(argv, '--language') as 'javascript' | 'typescript' | 'civet' | undefined
 
   options: CompilerOptions := {
     types:     argv.includes '--types'
@@ -24,7 +27,7 @@ export main := (argv: string[], input: string, filename: string = "<stdin>"): st
     tokenize:  argv.includes '--tokenize'
     filename: filename
     source: input
-    libPath: getOptValue('--libPath')
+    libPath: getOptValue(argv, '--libPath')
   }
   if language
     options.language = language

--- a/source/esbuild.civet
+++ b/source/esbuild.civet
@@ -2,6 +2,7 @@
 { relative } from node:path
 { compile } from ./main.civet
 type { CompilerOptions } from ./compiler.civet
+{ civetNotInstalledError } from ./register/civet/transpile.civet
 type { Plugin, Loader } from esbuild
 
 export interface HeraPluginOptions < CompilerOptions
@@ -37,10 +38,7 @@ export default function heraPlugin({ loader, ...heraOptions }: HeraPluginOptions
         try
           civet = await runtime.loadCivet()
         catch
-          throw new Error [
-            "[@danielx/hera] Civet support requires '@danielx/civet' to be installed."
-            "Run: npm install -D @danielx/civet"
-          ].join '\n'
+          throw civetNotInstalledError()
 
         // No { js: true } here — Civet outputs TypeScript, then esbuild strips
         // types with loader:'ts'. This preserves advanced TS features (const enum

--- a/source/hera.hera
+++ b/source/hera.hera
@@ -63,12 +63,10 @@ RuleBody
 
 Choice
   Sequence Handling ->
-    if ($2 !== undefined) {
-      if (!$1.push)
-        $1 = ["S", [$1], $2]
-      else
-        $1.push($2)
-    }
+    if ($2 === undefined) return $1
+    // A bare rule reference gets wrapped so the handler has somewhere to live
+    if (typeof $1 === "string") return ["S", [$1], $2]
+    $1.push($2)
     return $1
 
 Sequence
@@ -91,11 +89,8 @@ ParameterName
 
 Expression
   PrefixOperator? Suffix ParameterName? :: SequenceNode | NameNode ->
-    var result = null
-    if ($1) result = [$1, $2]
-    else result = $2
-    if ($3)
-      return [{name: $3}, result] as NameNode
+    const result = $1 ? [$1, $2] : $2
+    if ($3) return [{name: $3}, result] as NameNode
     return result as SequenceNode
 
 PrefixOperator

--- a/source/register/civet/transpile.civet
+++ b/source/register/civet/transpile.civet
@@ -11,6 +11,15 @@ export runtime =
     _require('@danielx/civet') as typeof import('@danielx/civet')
 
 /**
+Error raised when `@danielx/civet` (an optional peer) can't be loaded
+*/
+export civetNotInstalledError := (): Error ->
+  new Error [
+    "[@danielx/hera] Civet support requires '@danielx/civet' to be installed."
+    "Run: npm install -D @danielx/civet"
+  ].join '\n'
+
+/**
  * Compile a Civet source string to JavaScript.
  * Used by the Node CJS and ESM loaders.
  * Uses { sync: true } so the result is returned synchronously (required for CJS require.extensions).
@@ -20,10 +29,7 @@ export compileCivetToJs := (src: string, filename?: string, civetOptions?: Compi
     try
       runtime.loadCivet()
     catch
-      throw new Error [
-        "[@danielx/hera] Civet support requires '@danielx/civet' to be installed."
-        "Run: npm install @danielx/civet"
-      ].join '\n'
+      throw civetNotInstalledError()
   options := { ...civetOptions, ...(filename and { filename }), js: true, sync: true }
   result := civet.compile(src, options)
 

--- a/source/rules.json
+++ b/source/rules.json
@@ -156,10 +156,10 @@
         "Handling"
       ],
       {
-        "f": "    if ($2 !== undefined) {\n      if (!$1.push)\n        $1 = [\"S\", [$1], $2]\n      else\n        $1.push($2)\n    }\n    return $1",
+        "f": "    if ($2 === undefined) return $1\n    // A bare rule reference gets wrapped so the handler has somewhere to live\n    if (typeof $1 === \"string\") return [\"S\", [$1], $2]\n    $1.push($2)\n    return $1",
         "$loc": {
           "pos": 1666,
-          "length": 129
+          "length": 201
         }
       }
     ],
@@ -178,7 +178,7 @@
           {
             "f": "    $2.unshift($1)\n    return [\"S\", $2]",
             "$loc": {
-              "pos": 1856,
+              "pos": 1928,
               "length": 40
             },
             "t": " SequenceNode "
@@ -196,7 +196,7 @@
           {
             "f": "    $2.unshift($1)\n    return [\"/\", $2]",
             "$loc": {
-              "pos": 1946,
+              "pos": 2018,
               "length": 40
             },
             "t": " SequenceNode "
@@ -214,7 +214,7 @@
       {
         "f": "$2",
         "$loc": {
-          "pos": 2041,
+          "pos": 2113,
           "length": 4
         },
         "inline": true
@@ -234,7 +234,7 @@
       {
         "f": "$4",
         "$loc": {
-          "pos": 2094,
+          "pos": 2166,
           "length": 4
         },
         "inline": true
@@ -252,7 +252,7 @@
       {
         "f": "$2",
         "$loc": {
-          "pos": 2126,
+          "pos": 2198,
           "length": 4
         },
         "inline": true
@@ -272,10 +272,10 @@
         ]
       ],
       {
-        "f": "    var result = null\n    if ($1) result = [$1, $2]\n    else result = $2\n    if ($3)\n      return [{name: $3}, result] as NameNode\n    return result as SequenceNode",
+        "f": "    const result = $1 ? [$1, $2] : $2\n    if ($3) return [{name: $3}, result] as NameNode\n    return result as SequenceNode",
         "$loc": {
-          "pos": 2211,
-          "length": 166
+          "pos": 2283,
+          "length": 125
         },
         "t": " SequenceNode | NameNode "
       }
@@ -296,7 +296,7 @@
       {
         "f": "    if ($2) return [$2, $1]\n    else return $1",
         "$loc": {
-          "pos": 2437,
+          "pos": 2468,
           "length": 48
         }
       }
@@ -320,7 +320,7 @@
           {
             "f": "$2",
             "$loc": {
-              "pos": 2581,
+              "pos": 2612,
               "length": 4
             },
             "inline": true
@@ -346,7 +346,7 @@
           {
             "f": "    return undefined",
             "$loc": {
-              "pos": 2644,
+              "pos": 2675,
               "length": 21
             }
           }
@@ -378,7 +378,7 @@
           {
             "f": "    if (t) handler = { ...handler, t }\n    return handler as Handler",
             "$loc": {
-              "pos": 2728,
+              "pos": 2759,
               "length": 69
             }
           }
@@ -401,7 +401,7 @@
           {
             "f": "    return { t } as Handler",
             "$loc": {
-              "pos": 2969,
+              "pos": 3000,
               "length": 29
             }
           }
@@ -424,7 +424,7 @@
           {
             "f": "$2",
             "$loc": {
-              "pos": 3204,
+              "pos": 3235,
               "length": 49
             },
             "inline": true
@@ -438,7 +438,7 @@
           {
             "f": "    return {\n      f: $1.trimEnd(),\n      $loc,\n      inline: true,\n    }",
             "$loc": {
-              "pos": 3294,
+              "pos": 3325,
               "length": 75
             },
             "t": " Handler "
@@ -452,7 +452,7 @@
       {
         "f": "    return {\n      f: $1.join(\"\").trimEnd(),\n      $loc,\n    }",
         "$loc": {
-          "pos": 3432,
+          "pos": 3463,
           "length": 64
         },
         "t": " Handler "
@@ -505,7 +505,7 @@
       {
         "f": "    return $1 + $2.join(\"\") + ($3 ?? \"\")",
         "$loc": {
-          "pos": 3979,
+          "pos": 4010,
           "length": 42
         },
         "t": " string "
@@ -547,7 +547,7 @@
       {
         "f": "$2",
         "$loc": {
-          "pos": 4285,
+          "pos": 4316,
           "length": 4
         },
         "inline": true
@@ -584,7 +584,7 @@
       {
         "f": "[\"L\", $1]",
         "$loc": {
-          "pos": 4405,
+          "pos": 4436,
           "length": 11
         },
         "inline": true
@@ -608,7 +608,7 @@
           {
             "f": "    body = body.map((part) => typeof part === \"string\" ? normalizeRegExpSource(part) : part)\n    // Static heregexes use the normal RegExp path; only interpolated ones need RD.\n    if (body.every((part) => typeof part === \"string\"))\n      return [\"R\", body.join(\"\")]\n    return [\"RD\", body]",
             "$loc": {
-              "pos": 4476,
+              "pos": 4507,
               "length": 291
             }
           }
@@ -639,7 +639,7 @@
           {
             "f": "[\"R\", normalizeRegExpSource($3)]",
             "$loc": {
-              "pos": 4805,
+              "pos": 4836,
               "length": 33
             },
             "inline": true
@@ -651,7 +651,7 @@
           {
             "f": "[\"R\", normalizeRegExpSource($1)]",
             "$loc": {
-              "pos": 4869,
+              "pos": 4900,
               "length": 33
             },
             "inline": true
@@ -663,7 +663,7 @@
           {
             "f": "[\"R\", $1]",
             "$loc": {
-              "pos": 4911,
+              "pos": 4942,
               "length": 11
             },
             "inline": true
@@ -718,7 +718,7 @@
           {
             "f": "{ expression, constant: true }",
             "$loc": {
-              "pos": 5163,
+              "pos": 5194,
               "length": 125
             },
             "inline": true
@@ -751,7 +751,7 @@
           {
             "f": "{ expression }",
             "$loc": {
-              "pos": 5342,
+              "pos": 5373,
               "length": 15
             },
             "inline": true
@@ -764,7 +764,7 @@
           {
             "f": "\"\"",
             "$loc": {
-              "pos": 5425,
+              "pos": 5456,
               "length": 246
             },
             "inline": true
@@ -776,7 +776,7 @@
           {
             "f": "\"\"",
             "$loc": {
-              "pos": 5682,
+              "pos": 5713,
               "length": 67
             },
             "inline": true
@@ -788,7 +788,7 @@
           {
             "f": "\"\\\\/\"",
             "$loc": {
-              "pos": 5767,
+              "pos": 5798,
               "length": 116
             },
             "inline": true
@@ -800,7 +800,7 @@
           {
             "f": "$0",
             "$loc": {
-              "pos": 5907,
+              "pos": 5938,
               "length": 4
             },
             "inline": true
@@ -1035,7 +1035,7 @@
       {
         "f": "$2",
         "$loc": {
-          "pos": 7266,
+          "pos": 7297,
           "length": 4
         },
         "inline": true
@@ -1050,7 +1050,7 @@
       {
         "f": "    return {\n      type: \"CodeBlock\",\n      token: $0,\n      $loc,\n    }",
         "$loc": {
-          "pos": 7326,
+          "pos": 7357,
           "length": 73
         },
         "t": " CodeBlockNode "

--- a/source/util.civet
+++ b/source/util.civet
@@ -1,11 +1,36 @@
-{ parse } from ./main.civet
+parser from ./hera.hera
 
 {
   CodeSymbol
   type Handler
   type HeraAST
   type HeraRules
+  type RegExpPart
 } from ./hera-types.civet
+
+/**
+Source form of an interpolated `///` regex body
+*/
+heregexSource := (parts: RegExpPart[]): string ->
+  "///" + parts.map((part) ->
+    if part <? "string"
+      part
+    else if part.constant
+      "${const " + part.expression + "}"
+    else
+      "${" + part.expression + "}"
+  ).join("") + "///"
+
+/**
+True when `v` is a bare character class expression like `[a-z]+`, which can
+be written without surrounding slashes.
+*/
+isCharacterClass := (v: string): boolean ->
+  try
+    parser.parse v, startRule: "CharacterClassExpression"
+    true
+  catch
+    false
 
 /**
 Convert HeraRules to a Hera source text
@@ -64,25 +89,12 @@ toS := (rule: HeraAST, depth=0): string ->
         '"' + rule[1] + '"' + hToS(h)
       when "R"
         v := rule[1]
-        if v is "."
+        if v is "." or isCharacterClass v
           v + hToS(h)
         else
-          try
-            parse v,
-              startRule: "CharacterClassExpression"
-            v + hToS(h)
-          catch
-            '/' + v + '/' + hToS(h)
+          '/' + v + '/' + hToS(h)
       when "RD"
-        "///" + rule[1].map((part) =>
-          if part <? "string"
-            part
-          else if part.constant
-            "${const " + part.expression + "}"
-          else
-            "${" + part.expression + "}"
-        ).join("") + "///" + hToS(h)
-
+        heregexSource(rule[1]) + hToS(h)
       when "S"
         terms := rule[1].map (i) ->
           toS i, depth+1
@@ -138,24 +150,12 @@ ruleToEBNF := (rule: HeraAST, depth=0): string ->
         v := rule[1]
         if v is "."
           v
+        else if isCharacterClass v
+          quote v
         else
-          try
-            // throws if it's not a valid character class
-            parse v,
-              startRule: "CharacterClassExpression"
-            quote v
-          catch
-            quote('/' + v + '/')
+          quote('/' + v + '/')
       when "RD"
-        quote("///" + rule[1].map((part) =>
-          if part <? "string"
-            part
-          else if part.constant
-            "${const " + part.expression + "}"
-          else
-            "${" + part.expression + "}"
-        ).join("") + "///")
-
+        quote heregexSource(rule[1])
       when "S"
         terms := rule[1].map (rule) ->
           ruleToEBNF rule


### PR DESCRIPTION
## Summary

Small duplication and structure cleanups, no behavior change.

- **util.civet**: share the `///` heregex serialization and the bare-character-class probe between `toS` and `ruleToEBNF`. Import the parser directly from `hera.hera` instead of `main.civet`, which removes the `main` ⇄ `util` import cycle.
- **CLI**: export `getOptValue` from `cli.civet` and reuse it in `cli-bin.civet` instead of a second copy.
- **Loaders**: one `civetNotInstalledError` shared by the esbuild plugin and the civet register hook. They previously had the message inline with different install commands (`npm install -D` vs `npm install`); both now say `-D`.
- **hera.hera**: `Choice` checks `typeof $1 === "string"` instead of probing for `.push`; `Expression` uses a conditional instead of a null-initialized `var`. `rules.json` regenerated.

## Verification

- Parsed AST of `source/hera.hera`, every sample, and the inference fixture snapshotted before and after. All 17 non-Hera grammars are identical. The Hera grammar itself differs only in its own two handler bodies and the resulting `$loc` shifts.
- [x] `c8 mocha` — 209 passing, 100% coverage
- [x] `pnpm test:typed-parser-samples` (tsc checks the typed Hera grammar, exercising the new handler bodies)
- [x] `pnpm test:esbuild-plugin`
- [x] `pnpm test:loaders`
- [x] CLI smoke: `--version`, stdin with `--libPath`, `-o` with multiple inputs, and the missing `-o` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P6RAoyCaAv1Xe7FjMYwD3b
